### PR TITLE
#63 Basic logic to prevent section times and dwell times being changed by graph editing

### DIFF
--- a/Tests.Utility/Extensions/RandomExtensions.cs
+++ b/Tests.Utility/Extensions/RandomExtensions.cs
@@ -70,7 +70,6 @@ namespace Tests.Utility.Extensions
         {
             ArrivalDepartureOptions[] allValues = new ArrivalDepartureOptions[]
             {
-                0,
                 ArrivalDepartureOptions.Arrival,
                 ArrivalDepartureOptions.Departure,
                 ArrivalDepartureOptions.Arrival | ArrivalDepartureOptions.Departure

--- a/Tests.Utility/Extensions/RandomExtensions.cs
+++ b/Tests.Utility/Extensions/RandomExtensions.cs
@@ -55,6 +55,17 @@ namespace Tests.Utility.Extensions
             return new TimeOfDay(random.Next(86400));
         }
 
+        public static TimeOfDay NextTimeOfDayBefore(this Random random, TimeOfDay t)
+        {
+            return new TimeOfDay(random.Next(t.AbsoluteSeconds));
+        }
+
+        public static TimeOfDay NextTimeOfDayAfter(this Random random, TimeOfDay t)
+        {
+            int lim = 86400 - t.AbsoluteSeconds;
+            return new TimeOfDay(random.Next(lim) + t.AbsoluteSeconds);
+        }
+
         public static ArrivalDepartureOptions NextArrivalDepartureOptions(this Random random)
         {
             ArrivalDepartureOptions[] allValues = new ArrivalDepartureOptions[]

--- a/Tests.Utility/Providers/RandomProvider.cs
+++ b/Tests.Utility/Providers/RandomProvider.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Tests.Utility.Providers
+{
+    public static class RandomProvider
+    {
+        public static Random Default = new Random();
+    }
+}

--- a/Tests.Utility/Tests.Utility.csproj
+++ b/Tests.Utility/Tests.Utility.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Extensions\RandomExtensions.cs" />
     <Compile Include="MinimalUniqueItem.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Providers\RandomProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Timetabler.CoreData\Timetabler.CoreData.csproj">

--- a/Timetabler.CoreData.Tests.Unit/Comparers/ReferenceEqualityComparerUnitTests.cs
+++ b/Timetabler.CoreData.Tests.Unit/Comparers/ReferenceEqualityComparerUnitTests.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using Tests.Utility.Extensions;
+using Tests.Utility.Providers;
+using Timetabler.CoreData.Comparers;
+using Timetabler.Data;
+
+namespace Timetabler.CoreData.Tests.Unit.Comparers
+{
+    [TestClass]
+    public class ReferenceEqualityComparerUnitTests
+    {
+        private static Random _rnd = RandomProvider.Default;
+
+        [TestMethod]
+        public void ReferenceEqualityComparerClassEqualsMethodReturnsTrueWhenTheSameTimeOfDayObjectIsPassedToBothParameters()
+        {
+            TimeOfDay testParam = _rnd.NextTimeOfDay();
+            ReferenceEqualityComparer testObject = ReferenceEqualityComparer.Default;
+
+            bool testOutput = testObject.Equals(testParam, testParam);
+
+            Assert.IsTrue(testOutput);
+        }
+
+        [TestMethod]
+        public void ReferenceEqualityComparerClassEqualsMethodReturnsFalseWhenTwoDifferentButEqualTimeOfDayObjectsArePassedAsParameters()
+        {
+            TimeOfDay testParam0 = _rnd.NextTimeOfDay();
+            TimeOfDay testParam1 = new TimeOfDay(testParam0.AbsoluteSeconds);
+            ReferenceEqualityComparer testObject = ReferenceEqualityComparer.Default;
+
+            bool testOutput = testObject.Equals(testParam0, testParam1);
+
+            Assert.IsFalse(testOutput);
+            // Just to double-check that the parameters do compare equal!
+            Assert.AreEqual(testParam0, testParam1);
+        }
+    }
+}

--- a/Timetabler.CoreData.Tests.Unit/Timetabler.CoreData.Tests.Unit.csproj
+++ b/Timetabler.CoreData.Tests.Unit/Timetabler.CoreData.Tests.Unit.csproj
@@ -50,6 +50,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="Comparers\ReferenceEqualityComparerUnitTests.cs" />
     <Compile Include="Exceptions\TimetableLoaderExceptionUnitTests.cs" />
     <Compile Include="Helpers\CoordinateHelperUnitTests.cs" />
     <Compile Include="Helpers\GeneralHelperUnitTests.cs" />
@@ -65,6 +66,10 @@
     <ProjectReference Include="..\Timetabler.CoreData\Timetabler.CoreData.csproj">
       <Project>{80FFE281-9A15-4DA3-9E52-61FAC2979C2C}</Project>
       <Name>Timetabler.CoreData</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Timetabler.Data\Timetabler.Data.csproj">
+      <Project>{9A7E2940-50B8-4F3A-A535-AB6220E6CE3A}</Project>
+      <Name>Timetabler.Data</Name>
     </ProjectReference>
   </ItemGroup>
   <Choose>

--- a/Timetabler.CoreData/Comparers/ReferenceEqualityComparer.cs
+++ b/Timetabler.CoreData/Comparers/ReferenceEqualityComparer.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
-namespace Timetabler.CoreData.Helpers
+namespace Timetabler.CoreData.Comparers
 {
     /// <summary>
     /// An <see cref="IEqualityComparer" /> implementation which always compares strictly by reference equality even for types that implement their own Equals() method.

--- a/Timetabler.CoreData/Helpers/ReferenceEqualityComparer.cs
+++ b/Timetabler.CoreData/Helpers/ReferenceEqualityComparer.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Timetabler.CoreData.Helpers
+{
+    /// <summary>
+    /// An <see cref="IEqualityComparer" /> implementation which always compares strictly by reference equality even for types that implement their own Equals() method.
+    /// </summary>
+    public sealed class ReferenceEqualityComparer : IEqualityComparer, IEqualityComparer<object>
+    {
+        /// <summary>
+        /// The default instance of this comparer.
+        /// </summary>
+        public static readonly ReferenceEqualityComparer Default = new ReferenceEqualityComparer();
+
+        private ReferenceEqualityComparer() { }
+
+        /// <summary>
+        /// Returns true if the parameters are references to the same object instance, false if not.
+        /// </summary>
+        /// <param name="x">The first object</param>
+        /// <param name="y">The second object</param>
+        /// <returns>True if the objects are the same instance, false if not.</returns>
+        public new bool Equals(object x, object y)
+        {
+            return x == y;
+        }
+
+        /// <summary>
+        /// Return a hashcode for this object, using the runtime implementation.
+        /// </summary>
+        /// <param name="obj">The object to generate the hashcode of.</param>
+        /// <returns>An int representing the hashcode of the object.</returns>
+        public int GetHashCode(object obj)
+        {
+            return RuntimeHelpers.GetHashCode(obj);
+        }
+    }
+}

--- a/Timetabler.CoreData/Timetabler.CoreData.csproj
+++ b/Timetabler.CoreData/Timetabler.CoreData.csproj
@@ -48,7 +48,7 @@
     <Compile Include="Exceptions\TimetableLoaderException.cs" />
     <Compile Include="Helpers\CoordinateHelper.cs" />
     <Compile Include="Helpers\GeneralHelper.cs" />
-    <Compile Include="Helpers\ReferenceEqualityComparer.cs" />
+    <Compile Include="Comparers\ReferenceEqualityComparer.cs" />
     <Compile Include="Helpers\StringHelper.cs" />
     <Compile Include="Interfaces\ICopyableItem.cs" />
     <Compile Include="Interfaces\IUniqueItem.cs" />

--- a/Timetabler.CoreData/Timetabler.CoreData.csproj
+++ b/Timetabler.CoreData/Timetabler.CoreData.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Exceptions\TimetableLoaderException.cs" />
     <Compile Include="Helpers\CoordinateHelper.cs" />
     <Compile Include="Helpers\GeneralHelper.cs" />
+    <Compile Include="Helpers\ReferenceEqualityComparer.cs" />
     <Compile Include="Helpers\StringHelper.cs" />
     <Compile Include="Interfaces\ICopyableItem.cs" />
     <Compile Include="Interfaces\IUniqueItem.cs" />

--- a/Timetabler.Data.Tests.Unit/Comparers/VertexInformationTimeBasedComparerUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/Comparers/VertexInformationTimeBasedComparerUnitTests.cs
@@ -1,9 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Tests.Utility.Extensions;
 using Tests.Utility.Providers;
 using Timetabler.CoreData;

--- a/Timetabler.Data.Tests.Unit/Comparers/VertexInformationTimeBasedComparerUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/Comparers/VertexInformationTimeBasedComparerUnitTests.cs
@@ -1,0 +1,170 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Tests.Utility.Extensions;
+using Tests.Utility.Providers;
+using Timetabler.CoreData;
+using Timetabler.Data.Display;
+using Timetabler.Data.Display.Comparers;
+
+namespace Timetabler.Data.Tests.Unit.Comparers
+{
+    [TestClass]
+    public class VertexInformationTimeBasedComparerUnitTests
+    {
+        private static Random _rnd = RandomProvider.Default;
+
+        private ArrivalDepartureOptions GetArrivalDepartureOptions()
+        {
+            return (ArrivalDepartureOptions)(_rnd.Next(3) + 1);
+        }
+
+        private VertexInformation GetVertexInformation(TimeOfDay time)
+        {
+            return new VertexInformation(new TrainDrawingInfo { Train = new Train() }, time, GetArrivalDepartureOptions(), _rnd.NextDouble(), _rnd.NextDouble());
+        }
+
+        [TestMethod]
+        public void VertexInformationTimeBasedComparerClassCompareMethodReturnsMinusOneIfTimePropertyOfFirstParameterIsBeforeTimePropertyOfSecondParameter()
+        {
+            VertexInformation testParam0 = GetVertexInformation(_rnd.NextTimeOfDayBefore(new TimeOfDay(86398))); // make sure there are a couple of seconds left in the day
+            VertexInformation testParam1 = GetVertexInformation(_rnd.NextTimeOfDayAfter(testParam0.Time));
+            VertexInformationTimeBasedComparer testObject = new VertexInformationTimeBasedComparer();
+
+            int testOutput = testObject.Compare(testParam0, testParam1);
+
+            Assert.AreEqual(-1, testOutput);
+        }
+
+        [TestMethod]
+        public void VertexInformationTimeBasedComparerClassCompareMethodReturnsZeroIfTImePropertyOfFirstParameterIsEqualToTimePropertyOfSecondParameter()
+        {
+            VertexInformation testParam0 = GetVertexInformation(_rnd.NextTimeOfDay());
+            VertexInformation testParam1 = GetVertexInformation(testParam0.Time.Copy());
+            VertexInformationTimeBasedComparer testObject = new VertexInformationTimeBasedComparer();
+
+            int testOutput = testObject.Compare(testParam0, testParam1);
+
+            Assert.AreEqual(0, testOutput);
+        }
+
+        [TestMethod]
+        public void VertexInformationTimeBasedComparerClassCompareMethodReturnsZeroIfTImePropertyOfFirstParameterIsSameAsTimePropertyOfSecondParameter()
+        {
+            VertexInformation testParam0 = GetVertexInformation(_rnd.NextTimeOfDay());
+            VertexInformation testParam1 = GetVertexInformation(testParam0.Time);
+            VertexInformationTimeBasedComparer testObject = new VertexInformationTimeBasedComparer();
+
+            int testOutput = testObject.Compare(testParam0, testParam1);
+
+            Assert.AreEqual(0, testOutput);
+        }
+
+        [TestMethod]
+        public void VertexInformationTimeBasedComparerClassCompareMethodReturnsOneIfTimePropertyOfFirstParameterIsAfterTimePropertyOfSecondParameter()
+        {
+            VertexInformation testParam0 = GetVertexInformation(_rnd.NextTimeOfDayAfter(new TimeOfDay(1)));
+            VertexInformation testParam1 = GetVertexInformation(_rnd.NextTimeOfDayBefore(testParam0.Time));
+            VertexInformationTimeBasedComparer testObject = new VertexInformationTimeBasedComparer();
+
+            int testOutput = testObject.Compare(testParam0, testParam1);
+
+            Assert.AreEqual(1, testOutput);
+        }
+
+        [TestMethod]
+        public void VertexInformationTimeBasedComparerClassCompareMethodReturnsMinusOneIfFirstParameterIsNullAndSecondParameterIsNotNullAndHasNonNullTimeProperty()
+        {
+            VertexInformation testParam0 = null;
+            VertexInformation testParam1 = GetVertexInformation(_rnd.NextTimeOfDay());
+            VertexInformationTimeBasedComparer testObject = new VertexInformationTimeBasedComparer();
+
+            int testOutput = testObject.Compare(testParam0, testParam1);
+
+            Assert.AreEqual(-1, testOutput);
+        }
+
+        [TestMethod]
+        public void VertexInformationTimeBasedComparerClassCompareMethodReturnsMinusOneIfFirstParameterHasNullTimePropertyAndSecondParameterIsNotNullAndHasNonNullTimeProperty()
+        {
+            VertexInformation testParam0 = GetVertexInformation(null);
+            VertexInformation testParam1 = GetVertexInformation(_rnd.NextTimeOfDay());
+            VertexInformationTimeBasedComparer testObject = new VertexInformationTimeBasedComparer();
+
+            int testOutput = testObject.Compare(testParam0, testParam1);
+
+            Assert.AreEqual(-1, testOutput);
+        }
+
+        [TestMethod]
+        public void VertexInformationTimeBasedComparerClassCompareMethodReturnsOneIfFirstParameterIsNotNullAndHasNonNullTimePropertyAndSecondParameterIsNull()
+        {
+            VertexInformation testParam0 = GetVertexInformation(_rnd.NextTimeOfDay());
+            VertexInformation testParam1 = null;
+            VertexInformationTimeBasedComparer testObject = new VertexInformationTimeBasedComparer();
+
+            int testOutput = testObject.Compare(testParam0, testParam1);
+
+            Assert.AreEqual(1, testOutput);
+        }
+
+        [TestMethod]
+        public void VertexInformationTimeBasedComparerClassCompareMethodReturnsOneIfFirstParameterIsNotNullAndHasNonNullTimePropertyAndSecondParameterHasNullTimeProperty()
+        {
+            VertexInformation testParam0 = GetVertexInformation(_rnd.NextTimeOfDay());
+            VertexInformation testParam1 = GetVertexInformation(null);
+            VertexInformationTimeBasedComparer testObject = new VertexInformationTimeBasedComparer();
+
+            int testOutput = testObject.Compare(testParam0, testParam1);
+
+            Assert.AreEqual(1, testOutput);
+        }
+
+        [TestMethod]
+        public void VertexInformationTimeBasedComparerClassCompareMethodReturnsZeroIfBothParametersAreNull()
+        {
+            VertexInformationTimeBasedComparer testObject = new VertexInformationTimeBasedComparer();
+
+            int testOutput = testObject.Compare(null, null);
+
+            Assert.AreEqual(0, testOutput);
+        }
+
+        [TestMethod]
+        public void VertexInformationTimeBasedComparerClassCompareMethodReturnsZeroIfFirstParameterIsNullAndSecondParameterHasNullTimeProperty()
+        {
+            VertexInformation testParam = GetVertexInformation(null);
+            VertexInformationTimeBasedComparer testObject = new VertexInformationTimeBasedComparer();
+
+            int testOutput = testObject.Compare(null, testParam);
+
+            Assert.AreEqual(0, testOutput);
+        }
+
+        [TestMethod]
+        public void VertexInformationTimeBasedComparerClassCompareMethodReturnsZeroIfFirstParameterHasNullTimePropertyAndSecondParameterIsNull()
+        {
+            VertexInformation testParam = GetVertexInformation(null);
+            VertexInformationTimeBasedComparer testObject = new VertexInformationTimeBasedComparer();
+
+            int testOutput = testObject.Compare(testParam, null);
+
+            Assert.AreEqual(0, testOutput);
+        }
+
+        [TestMethod]
+        public void VertexInformationTimeBasedComparerClassCompareMethodReturnsZeroIfBothParametersHaveNullTimeProperty()
+        {
+            VertexInformation testParam0 = GetVertexInformation(null);
+            VertexInformation testParam1 = GetVertexInformation(null);
+            VertexInformationTimeBasedComparer testObject = new VertexInformationTimeBasedComparer();
+
+            int testOutput = testObject.Compare(testParam0, testParam1);
+
+            Assert.AreEqual(0, testOutput);
+        }
+    }
+}

--- a/Timetabler.Data.Tests.Unit/Display/LineCoordinatesUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/Display/LineCoordinatesUnitTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using Tests.Utility.Extensions;
+using Tests.Utility.Providers;
 using Timetabler.CoreData;
 using Timetabler.Data.Display;
 
@@ -10,13 +11,13 @@ namespace Timetabler.Data.Tests.Unit.Display
     [TestClass]
     public class LineCoordinatesUnitTests
     {
-        private static Random _rnd = new Random();
+        private static Random _rnd = RandomProvider.Default;
 
         [TestMethod]
         public void LineCoordinatesClassConstructorSetsVertex1PropertyToValueOfFirstParameter()
         {
-            VertexInformation testParam0 = new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
-            VertexInformation testParam1 = new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
+            VertexInformation testParam0 = new VertexInformation(new TrainDrawingInfo(), _rnd.NextTimeOfDay(), _rnd.NextArrivalDepartureOptions(), _rnd.NextDouble(), _rnd.NextDouble());
+            VertexInformation testParam1 = new VertexInformation(new TrainDrawingInfo(), _rnd.NextTimeOfDay(), _rnd.NextArrivalDepartureOptions(), _rnd.NextDouble(), _rnd.NextDouble());
 
             LineCoordinates testOutput = new LineCoordinates(testParam0, testParam1);
 
@@ -26,8 +27,8 @@ namespace Timetabler.Data.Tests.Unit.Display
         [TestMethod]
         public void LineCoordinatesClassConstructorSetsVertex2PropertyToValueOfSecondParameter()
         {
-            VertexInformation testParam0 = new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
-            VertexInformation testParam1 = new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
+            VertexInformation testParam0 = new VertexInformation(new TrainDrawingInfo(), _rnd.NextTimeOfDay(), _rnd.NextArrivalDepartureOptions(), _rnd.NextDouble(), _rnd.NextDouble());
+            VertexInformation testParam1 = new VertexInformation(new TrainDrawingInfo(), _rnd.NextTimeOfDay(), _rnd.NextArrivalDepartureOptions(), _rnd.NextDouble(), _rnd.NextDouble());
 
             LineCoordinates testOutput = new LineCoordinates(testParam0, testParam1);
 
@@ -70,13 +71,8 @@ namespace Timetabler.Data.Tests.Unit.Display
         {
             List<LineCoordinates> testInput = new List<LineCoordinates>
             {
-                new LineCoordinates(new VertexInformation(
-                        new TrainDrawingInfo(), 
-                        new TimeOfDay(_rnd.Next(86400)), 
-                        (ArrivalDepartureOptions)(_rnd.Next(3) + 1), 
-                        _rnd.NextDouble(), 
-                        _rnd.NextDouble()),
-                    new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble()))
+                new LineCoordinates(new VertexInformation(new TrainDrawingInfo(), _rnd.NextTimeOfDay(), _rnd.NextArrivalDepartureOptions(), _rnd.NextDouble(), _rnd.NextDouble()),
+                    new VertexInformation(new TrainDrawingInfo(), _rnd.NextTimeOfDay(), _rnd.NextArrivalDepartureOptions(), _rnd.NextDouble(), _rnd.NextDouble()))
             };
 
             int testOutput = LineCoordinates.GetIndexOfLongestLine(testInput);
@@ -88,13 +84,9 @@ namespace Timetabler.Data.Tests.Unit.Display
         public void LineCoordinatesClassGetIndexOfLongestLineMethodReturnsIndexOfNonNullItemIfParameterOnlyContainsOneNonNullItem()
         {
             List<LineCoordinates> testInput = new List<LineCoordinates>();
-            LineCoordinates testItem = new LineCoordinates(new VertexInformation(
-                    new TrainDrawingInfo(), 
-                    new TimeOfDay(_rnd.Next(86400)), 
-                    (ArrivalDepartureOptions)(_rnd.Next(3) + 1), 
-                    _rnd.NextDouble(), 
-                    _rnd.NextDouble()),
-                new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble()));
+            LineCoordinates testItem = 
+                new LineCoordinates(new VertexInformation(new TrainDrawingInfo(), _rnd.NextTimeOfDay(), _rnd.NextArrivalDepartureOptions(), _rnd.NextDouble(), _rnd.NextDouble()),
+                    new VertexInformation(new TrainDrawingInfo(), _rnd.NextTimeOfDay(), _rnd.NextArrivalDepartureOptions(), _rnd.NextDouble(), _rnd.NextDouble()));
             int count = _rnd.Next(20) + 1;
             int pos = _rnd.Next(count);
             for (int i = 0; i < count; ++i)
@@ -120,11 +112,11 @@ namespace Timetabler.Data.Tests.Unit.Display
             List<LineCoordinates> testInput = new List<LineCoordinates>(count);
             for (int i = 0; i < count; ++i)
             {
-                VertexInformation startVertex = new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), 
-                    _rnd.NextDouble() * 200, _rnd.NextDouble() * 200);
+                VertexInformation startVertex = new VertexInformation(new TrainDrawingInfo(), _rnd.NextTimeOfDay(), _rnd.NextArrivalDepartureOptions(), _rnd.NextDouble() * 200, 
+                    _rnd.NextDouble() * 200);
                 double theta = _rnd.NextDouble() * Math.PI * 2;
-                VertexInformation endVertex = new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), 
-                    startVertex.X + lengths[i] * Math.Cos(theta), startVertex.Y + lengths[i] * Math.Sin(theta));
+                VertexInformation endVertex = new VertexInformation(new TrainDrawingInfo(), _rnd.NextTimeOfDay(), _rnd.NextArrivalDepartureOptions(), startVertex.X + lengths[i] * Math.Cos(theta), 
+                    startVertex.Y + lengths[i] * Math.Sin(theta));
                 testInput.Add(new LineCoordinates(startVertex, endVertex));
             }
 

--- a/Timetabler.Data.Tests.Unit/Display/LineCoordinatesUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/Display/LineCoordinatesUnitTests.cs
@@ -15,8 +15,8 @@ namespace Timetabler.Data.Tests.Unit.Display
         [TestMethod]
         public void LineCoordinatesClassConstructorSetsVertex1PropertyToValueOfFirstParameter()
         {
-            VertexInformation testParam0 = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
-            VertexInformation testParam1 = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
+            VertexInformation testParam0 = new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
+            VertexInformation testParam1 = new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
 
             LineCoordinates testOutput = new LineCoordinates(testParam0, testParam1);
 
@@ -26,8 +26,8 @@ namespace Timetabler.Data.Tests.Unit.Display
         [TestMethod]
         public void LineCoordinatesClassConstructorSetsVertex2PropertyToValueOfSecondParameter()
         {
-            VertexInformation testParam0 = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
-            VertexInformation testParam1 = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
+            VertexInformation testParam0 = new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
+            VertexInformation testParam1 = new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
 
             LineCoordinates testOutput = new LineCoordinates(testParam0, testParam1);
 
@@ -70,8 +70,13 @@ namespace Timetabler.Data.Tests.Unit.Display
         {
             List<LineCoordinates> testInput = new List<LineCoordinates>
             {
-                new LineCoordinates(new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble()),
-                    new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble()))
+                new LineCoordinates(new VertexInformation(
+                        new TrainDrawingInfo(), 
+                        new TimeOfDay(_rnd.Next(86400)), 
+                        (ArrivalDepartureOptions)(_rnd.Next(3) + 1), 
+                        _rnd.NextDouble(), 
+                        _rnd.NextDouble()),
+                    new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble()))
             };
 
             int testOutput = LineCoordinates.GetIndexOfLongestLine(testInput);
@@ -83,9 +88,13 @@ namespace Timetabler.Data.Tests.Unit.Display
         public void LineCoordinatesClassGetIndexOfLongestLineMethodReturnsIndexOfNonNullItemIfParameterOnlyContainsOneNonNullItem()
         {
             List<LineCoordinates> testInput = new List<LineCoordinates>();
-            LineCoordinates testItem = new LineCoordinates(new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), 
+            LineCoordinates testItem = new LineCoordinates(new VertexInformation(
+                    new TrainDrawingInfo(), 
+                    new TimeOfDay(_rnd.Next(86400)), 
+                    (ArrivalDepartureOptions)(_rnd.Next(3) + 1), 
+                    _rnd.NextDouble(), 
                     _rnd.NextDouble()),
-                new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble()));
+                new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble()));
             int count = _rnd.Next(20) + 1;
             int pos = _rnd.Next(count);
             for (int i = 0; i < count; ++i)
@@ -111,10 +120,10 @@ namespace Timetabler.Data.Tests.Unit.Display
             List<LineCoordinates> testInput = new List<LineCoordinates>(count);
             for (int i = 0; i < count; ++i)
             {
-                VertexInformation startVertex = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble() * 200, 
-                    _rnd.NextDouble() * 200);
+                VertexInformation startVertex = new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), 
+                    _rnd.NextDouble() * 200, _rnd.NextDouble() * 200);
                 double theta = _rnd.NextDouble() * Math.PI * 2;
-                VertexInformation endVertex = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), 
+                VertexInformation endVertex = new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), 
                     startVertex.X + lengths[i] * Math.Cos(theta), startVertex.Y + lengths[i] * Math.Sin(theta));
                 testInput.Add(new LineCoordinates(startVertex, endVertex));
             }

--- a/Timetabler.Data.Tests.Unit/Display/LineCoordinatesUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/Display/LineCoordinatesUnitTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using Tests.Utility.Extensions;
+using Timetabler.CoreData;
 using Timetabler.Data.Display;
 
 namespace Timetabler.Data.Tests.Unit.Display
@@ -14,8 +15,8 @@ namespace Timetabler.Data.Tests.Unit.Display
         [TestMethod]
         public void LineCoordinatesClassConstructorSetsVertex1PropertyToValueOfFirstParameter()
         {
-            VertexInformation testParam0 = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), _rnd.NextDouble(), _rnd.NextDouble());
-            VertexInformation testParam1 = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), _rnd.NextDouble(), _rnd.NextDouble());
+            VertexInformation testParam0 = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
+            VertexInformation testParam1 = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
 
             LineCoordinates testOutput = new LineCoordinates(testParam0, testParam1);
 
@@ -25,8 +26,8 @@ namespace Timetabler.Data.Tests.Unit.Display
         [TestMethod]
         public void LineCoordinatesClassConstructorSetsVertex2PropertyToValueOfSecondParameter()
         {
-            VertexInformation testParam0 = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), _rnd.NextDouble(), _rnd.NextDouble());
-            VertexInformation testParam1 = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), _rnd.NextDouble(), _rnd.NextDouble());
+            VertexInformation testParam0 = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
+            VertexInformation testParam1 = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
 
             LineCoordinates testOutput = new LineCoordinates(testParam0, testParam1);
 
@@ -69,8 +70,8 @@ namespace Timetabler.Data.Tests.Unit.Display
         {
             List<LineCoordinates> testInput = new List<LineCoordinates>
             {
-                new LineCoordinates(new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), _rnd.NextDouble(), _rnd.NextDouble()),
-                    new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), _rnd.NextDouble(), _rnd.NextDouble()))
+                new LineCoordinates(new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble()),
+                    new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble()))
             };
 
             int testOutput = LineCoordinates.GetIndexOfLongestLine(testInput);
@@ -82,8 +83,9 @@ namespace Timetabler.Data.Tests.Unit.Display
         public void LineCoordinatesClassGetIndexOfLongestLineMethodReturnsIndexOfNonNullItemIfParameterOnlyContainsOneNonNullItem()
         {
             List<LineCoordinates> testInput = new List<LineCoordinates>();
-            LineCoordinates testItem = new LineCoordinates(new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), _rnd.NextDouble(), _rnd.NextDouble()),
-                new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), _rnd.NextDouble(), _rnd.NextDouble()));
+            LineCoordinates testItem = new LineCoordinates(new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), 
+                    _rnd.NextDouble()),
+                new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble()));
             int count = _rnd.Next(20) + 1;
             int pos = _rnd.Next(count);
             for (int i = 0; i < count; ++i)
@@ -109,10 +111,11 @@ namespace Timetabler.Data.Tests.Unit.Display
             List<LineCoordinates> testInput = new List<LineCoordinates>(count);
             for (int i = 0; i < count; ++i)
             {
-                VertexInformation startVertex = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), _rnd.NextDouble() * 200, _rnd.NextDouble() * 200);
+                VertexInformation startVertex = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble() * 200, 
+                    _rnd.NextDouble() * 200);
                 double theta = _rnd.NextDouble() * Math.PI * 2;
-                VertexInformation endVertex = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), startVertex.X + lengths[i] * Math.Cos(theta), 
-                    startVertex.Y + lengths[i] * Math.Sin(theta));
+                VertexInformation endVertex = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), 
+                    startVertex.X + lengths[i] * Math.Cos(theta), startVertex.Y + lengths[i] * Math.Sin(theta));
                 testInput.Add(new LineCoordinates(startVertex, endVertex));
             }
 

--- a/Timetabler.Data.Tests.Unit/Display/TrainDrawingInfoUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/Display/TrainDrawingInfoUnitTests.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Tests.Utility.Extensions;
+using Tests.Utility.Providers;
+using Timetabler.Data.Display;
+
+namespace Timetabler.Data.Tests.Unit.Display
+{
+    [TestClass]
+    public class TrainDrawingInfoUnitTests
+    {
+        private static Random _rnd = RandomProvider.Default;
+
+        private VertexInformation GetVertexInformation(TrainDrawingInfo tdi)
+        {
+            return new VertexInformation(tdi, _rnd.NextTimeOfDay(), _rnd.NextArrivalDepartureOptions(), _rnd.NextDouble(), _rnd.NextDouble());
+        }
+
+        [TestMethod]
+        public void TrainDrawingInfoClassLineVertexesPropertyGetMethodReturnsAllVertexesFromAllLines()
+        {
+            int lineCount = _rnd.Next(10) + 1;
+            TrainDrawingInfo testObject = new TrainDrawingInfo();
+            List<VertexInformation> vertexList = new List<VertexInformation>(lineCount * 2);
+            for (int i = 0; i < lineCount; ++i)
+            {
+                LineCoordinates line = new LineCoordinates(GetVertexInformation(testObject), GetVertexInformation(testObject));
+                vertexList.Add(line.Vertex1);
+                vertexList.Add(line.Vertex2);
+                testObject.Lines.Add(line);
+            }
+
+            List<VertexInformation> testOutput = testObject.LineVertexes.ToList();
+
+            Assert.AreEqual(vertexList.Count, testOutput.Count);
+            foreach (VertexInformation vi in testOutput)
+            {
+                Assert.IsTrue(vertexList.Contains(vi));
+                vertexList.Remove(vi);
+            }
+        }
+
+        [TestMethod]
+        public void TrainDrawingInfoClassLineVertexesPropertyGetMethodOnlyReturnsDistinctVertexesWhereVertexObjectsAreSharedBetweenLines()
+        {
+            TrainDrawingInfo testObject = new TrainDrawingInfo();
+            int vertexCount = _rnd.Next(10) + 1;
+            int lineCount = _rnd.Next(10) + vertexCount;
+            VertexInformation[] vertexSource = new VertexInformation[vertexCount];
+            bool[] vertexesUsed = new bool[vertexCount];
+            for (int i = 0; i < vertexCount; ++i)
+            {
+                vertexSource[i] = GetVertexInformation(testObject);
+            }
+            for (int i = 0; i < lineCount; ++i)
+            {
+                int firstIndex = _rnd.Next(vertexCount);
+                int secondIndex = _rnd.Next(vertexCount);
+                testObject.Lines.Add(new LineCoordinates(vertexSource[firstIndex], vertexSource[secondIndex]));
+                vertexesUsed[firstIndex] = true;
+                vertexesUsed[secondIndex] = true;
+            }
+            List<VertexInformation> vertexList = vertexSource.Where((v, i) => vertexesUsed[i]).ToList();
+
+            List<VertexInformation> testOutput = testObject.LineVertexes.ToList();
+
+            Assert.AreEqual(vertexList.Count, testOutput.Count);
+            foreach (VertexInformation vi in testOutput)
+            {
+                Assert.IsTrue(vertexList.Contains(vi));
+                vertexList.Remove(vi);
+            }
+        }
+    }
+}

--- a/Timetabler.Data.Tests.Unit/Display/TrainGraphModelUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/Display/TrainGraphModelUnitTests.cs
@@ -1,10 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Tests.Utility.Extensions;
+using Tests.Utility.Providers;
 using Timetabler.Data.Display;
 
 namespace Timetabler.Data.Tests.Unit.Display
@@ -12,7 +9,7 @@ namespace Timetabler.Data.Tests.Unit.Display
     [TestClass]
     public class TrainGraphModelUnitTests
     {
-        private static Random _rnd = new Random();
+        private static Random _rnd = RandomProvider.Default;
 
         private TrainGraphModel GetTrainGraphModel()
         {

--- a/Timetabler.Data.Tests.Unit/Display/TrainGraphModelUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/Display/TrainGraphModelUnitTests.cs
@@ -1,0 +1,111 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Tests.Utility.Extensions;
+using Timetabler.Data.Display;
+
+namespace Timetabler.Data.Tests.Unit.Display
+{
+    [TestClass]
+    public class TrainGraphModelUnitTests
+    {
+        private static Random _rnd = new Random();
+
+        private TrainGraphModel GetTrainGraphModel()
+        {
+            return new TrainGraphModel
+            {
+                DisplayTrainLabels = _rnd.NextBoolean(),
+                GraphEditStyle = _rnd.NextBoolean() ? GraphEditStyle.Free : GraphEditStyle.PreserveSectionTimes,
+                TooltipFormattingString = _rnd.NextString(_rnd.Next(5)),
+            };
+        }
+
+        private DocumentOptions GetDocumentOptions()
+        {
+            return new DocumentOptions
+            {
+                DisplayTrainLabelsOnGraphs = _rnd.NextBoolean(),
+                ClockType = _rnd.NextBoolean() ? ClockType.TwelveHourClock : ClockType.TwentyFourHourClock,
+                GraphEditStyle = _rnd.NextBoolean() ? GraphEditStyle.Free : GraphEditStyle.PreserveSectionTimes
+            };
+        }
+
+        [TestMethod]
+        public void TrainGraphModelClassSetPropertiesFromDocumentOptionsMethodSetsDisplayTrainLabelsPropertyToEqualDisplayTrainLabelsOnGraphsPropertyOfParameter()
+        {
+            DocumentOptions testSource = GetDocumentOptions();
+            TrainGraphModel testObject = GetTrainGraphModel();
+
+            testObject.SetPropertiesFromDocumentOptions(testSource);
+
+            Assert.AreEqual(testSource.DisplayTrainLabelsOnGraphs, testObject.DisplayTrainLabels);
+        }
+
+        [TestMethod]
+        public void TrainGraphModelClassSetPropertiesFromDocumentOptionsMethodDoesNotCrashIfParameterIsNull()
+        {
+            TrainGraphModel testObject = GetTrainGraphModel();
+
+            testObject.SetPropertiesFromDocumentOptions(null);
+        }
+
+        [TestMethod]
+        public void TrainGraphModelClassSetPropertiesFromDocumentOptionsMethodDoesNotChangeDisplayTrainLabelsPropertyIfParameterIsNull()
+        {
+            TrainGraphModel testObject = GetTrainGraphModel();
+            bool displayLabels = testObject.DisplayTrainLabels;
+
+            testObject.SetPropertiesFromDocumentOptions(null);
+
+            Assert.AreEqual(displayLabels, testObject.DisplayTrainLabels);
+        }
+
+        [TestMethod]
+        public void TrainGraphModelClassSetPropertiesFromDocumentOptionsMethodDoesNotChangeGraphEditStylePropertyIfParameterIsNull()
+        {
+            TrainGraphModel testObject = GetTrainGraphModel();
+            GraphEditStyle graphEditStyle = testObject.GraphEditStyle;
+
+            testObject.SetPropertiesFromDocumentOptions(null);
+
+            Assert.AreEqual(graphEditStyle, testObject.GraphEditStyle);
+        }
+
+        [TestMethod]
+        public void TrainGraphModelClassSetPropertiesFromDocumentOptionsMethodDoesNotChangeTooltipFormattingStringPropertyIfParameterIsNull()
+        {
+            TrainGraphModel testObject = GetTrainGraphModel();
+            string ttf = testObject.TooltipFormattingString;
+
+            testObject.SetPropertiesFromDocumentOptions(null);
+
+            Assert.AreEqual(ttf, testObject.TooltipFormattingString);
+        }
+
+        [TestMethod]
+        public void TrainGraphModelClassSetPropertiesFromDocumentOptionsMethodSetsGraphEditStylePropertyToEqualGraphEditStylePropertyOfParameter()
+        {
+            DocumentOptions testSource = GetDocumentOptions();
+            TrainGraphModel testObject = GetTrainGraphModel();
+
+            testObject.SetPropertiesFromDocumentOptions(testSource);
+
+            Assert.AreEqual(testSource.GraphEditStyle, testObject.GraphEditStyle);
+        }
+
+        [TestMethod]
+        public void TrainGraphModelClassSetPropertiesFromDocumentOptionsMethodSetsTooltipFormattingStringPropertyToEqualTooltipPropertyOfFormattingStringsPropertyOfParameter()
+        {
+            DocumentOptions testSource = GetDocumentOptions();
+            TrainGraphModel testObject = GetTrainGraphModel();
+
+            testObject.SetPropertiesFromDocumentOptions(testSource);
+
+            Assert.AreEqual(testSource.FormattingStrings.Tooltip, testObject.TooltipFormattingString);
+        }
+    }
+}

--- a/Timetabler.Data.Tests.Unit/Display/VertexInformationUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/Display/VertexInformationUnitTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using Timetabler.CoreData;
 using Timetabler.Data.Display;
 
 namespace Timetabler.Data.Tests.Unit.Display
@@ -14,10 +15,11 @@ namespace Timetabler.Data.Tests.Unit.Display
         {
             Train testParam0 = new Train();
             TimeOfDay testParam1 = new TimeOfDay(_rnd.Next(86400));
-            double testParam2 = _rnd.NextDouble();
+            ArrivalDepartureOptions testParam2 = (ArrivalDepartureOptions)(_rnd.Next(3) + 1);
             double testParam3 = _rnd.NextDouble();
+            double testParam4 = _rnd.NextDouble();
 
-            VertexInformation testOutput = new VertexInformation(testParam0, testParam1, testParam2, testParam3);
+            VertexInformation testOutput = new VertexInformation(testParam0, testParam1, testParam2, testParam3, testParam4);
 
             Assert.AreSame(testParam0, testOutput.Train);
         }
@@ -27,38 +29,53 @@ namespace Timetabler.Data.Tests.Unit.Display
         {
             Train testParam0 = new Train();
             TimeOfDay testParam1 = new TimeOfDay(_rnd.Next(86400));
-            double testParam2 = _rnd.NextDouble();
+            ArrivalDepartureOptions testParam2 = (ArrivalDepartureOptions)(_rnd.Next(3) + 1);
             double testParam3 = _rnd.NextDouble();
+            double testParam4 = _rnd.NextDouble();
 
-            VertexInformation testOutput = new VertexInformation(testParam0, testParam1, testParam2, testParam3);
+            VertexInformation testOutput = new VertexInformation(testParam0, testParam1, testParam2, testParam3, testParam4);
 
             Assert.AreEqual(testParam1, testOutput.Time);
         }
 
         [TestMethod]
-        public void VertexInformationClassConstructorSetsXPropertyToValueOfThirdParameter()
+        public void VertexInformationClassConstructorSetsArrivalDeparturePropertyToValueOfThirdParameter()
         {
             Train testParam0 = new Train();
             TimeOfDay testParam1 = new TimeOfDay(_rnd.Next(86400));
-            double testParam2 = _rnd.NextDouble();
+            ArrivalDepartureOptions testParam2 = (ArrivalDepartureOptions)(_rnd.Next(3) + 1);
             double testParam3 = _rnd.NextDouble();
+            double testParam4 = _rnd.NextDouble();
 
-            VertexInformation testOutput = new VertexInformation(testParam0, testParam1, testParam2, testParam3);
+            VertexInformation testOutput = new VertexInformation(testParam0, testParam1, testParam2, testParam3, testParam4);
 
-            Assert.AreEqual(testParam2, testOutput.X);
+            Assert.AreEqual(testParam2, testOutput.ArrivalDeparture);
         }
 
         [TestMethod]
-        public void VertexInformationClassConstructorSetsYPropertyToValueOfFourthParameter()
+        public void VertexInformationClassConstructorSetsXPropertyToValueOfFourthParameter()
         {
             Train testParam0 = new Train();
             TimeOfDay testParam1 = new TimeOfDay(_rnd.Next(86400));
-            double testParam2 = _rnd.NextDouble();
+            ArrivalDepartureOptions testParam2 = (ArrivalDepartureOptions)(_rnd.Next(3) + 1);
             double testParam3 = _rnd.NextDouble();
+            double testParam4 = _rnd.NextDouble();
 
-            VertexInformation testOutput = new VertexInformation(testParam0, testParam1, testParam2, testParam3);
+            VertexInformation testOutput = new VertexInformation(testParam0, testParam1, testParam2, testParam3, testParam4);
+        }
 
-            Assert.AreEqual(testParam3, testOutput.Y);
+        [TestMethod]
+        public void VertexInformationClassConstructorSetsYPropertyToValueOfFifthParameter()
+        {
+            Train testParam0 = new Train();
+            TimeOfDay testParam1 = new TimeOfDay(_rnd.Next(86400));
+            ArrivalDepartureOptions testParam2 = (ArrivalDepartureOptions)(_rnd.Next(3) + 1);
+            double testParam3 = _rnd.NextDouble();
+            double testParam4 = _rnd.NextDouble();
+
+            VertexInformation testOutput = new VertexInformation(testParam0, testParam1, testParam2, testParam3, testParam4);
+
+            Assert.AreEqual(testParam4, testOutput.Y);
         }
     }
 }

--- a/Timetabler.Data.Tests.Unit/Display/VertexInformationUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/Display/VertexInformationUnitTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using Tests.Utility.Providers;
 using Timetabler.CoreData;
 using Timetabler.Data.Display;
 
@@ -8,7 +9,7 @@ namespace Timetabler.Data.Tests.Unit.Display
     [TestClass]
     public class VertexInformationUnitTests
     {
-        private static Random _rnd = new Random();
+        private static Random _rnd = RandomProvider.Default;
 
         [TestMethod]
         public void VertexInformationClassConstructorSetsTrainDrawingInfoPropertyToValueOfFirstParameter()

--- a/Timetabler.Data.Tests.Unit/Display/VertexInformationUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/Display/VertexInformationUnitTests.cs
@@ -11,9 +11,9 @@ namespace Timetabler.Data.Tests.Unit.Display
         private static Random _rnd = new Random();
 
         [TestMethod]
-        public void VertexInformationClassConstructorSetsTrainPropertyToValueOfFirstParameter()
+        public void VertexInformationClassConstructorSetsTrainDrawingInfoPropertyToValueOfFirstParameter()
         {
-            Train testParam0 = new Train();
+            TrainDrawingInfo testParam0 = new TrainDrawingInfo { Train = new Train() };
             TimeOfDay testParam1 = new TimeOfDay(_rnd.Next(86400));
             ArrivalDepartureOptions testParam2 = (ArrivalDepartureOptions)(_rnd.Next(3) + 1);
             double testParam3 = _rnd.NextDouble();
@@ -21,13 +21,27 @@ namespace Timetabler.Data.Tests.Unit.Display
 
             VertexInformation testOutput = new VertexInformation(testParam0, testParam1, testParam2, testParam3, testParam4);
 
-            Assert.AreSame(testParam0, testOutput.Train);
+            Assert.AreSame(testParam0, testOutput.TrainDrawingInfo);
+        }
+
+        [TestMethod]
+        public void VertexInformationClassConstructorSetsTrainPropertyToValueOfTrainPropertyOfFirstParameter()
+        {
+            TrainDrawingInfo testParam0 = new TrainDrawingInfo { Train = new Train() };
+            TimeOfDay testParam1 = new TimeOfDay(_rnd.Next(86400));
+            ArrivalDepartureOptions testParam2 = (ArrivalDepartureOptions)(_rnd.Next(3) + 1);
+            double testParam3 = _rnd.NextDouble();
+            double testParam4 = _rnd.NextDouble();
+
+            VertexInformation testOutput = new VertexInformation(testParam0, testParam1, testParam2, testParam3, testParam4);
+
+            Assert.AreSame(testParam0.Train, testOutput.Train);
         }
 
         [TestMethod]
         public void VertexInformationClassConstructorSetsTimePropertyToValueOfSecondParameter()
         {
-            Train testParam0 = new Train();
+            TrainDrawingInfo testParam0 = new TrainDrawingInfo { Train = new Train() };
             TimeOfDay testParam1 = new TimeOfDay(_rnd.Next(86400));
             ArrivalDepartureOptions testParam2 = (ArrivalDepartureOptions)(_rnd.Next(3) + 1);
             double testParam3 = _rnd.NextDouble();
@@ -41,7 +55,7 @@ namespace Timetabler.Data.Tests.Unit.Display
         [TestMethod]
         public void VertexInformationClassConstructorSetsArrivalDeparturePropertyToValueOfThirdParameter()
         {
-            Train testParam0 = new Train();
+            TrainDrawingInfo testParam0 = new TrainDrawingInfo { Train = new Train() };
             TimeOfDay testParam1 = new TimeOfDay(_rnd.Next(86400));
             ArrivalDepartureOptions testParam2 = (ArrivalDepartureOptions)(_rnd.Next(3) + 1);
             double testParam3 = _rnd.NextDouble();
@@ -55,7 +69,7 @@ namespace Timetabler.Data.Tests.Unit.Display
         [TestMethod]
         public void VertexInformationClassConstructorSetsXPropertyToValueOfFourthParameter()
         {
-            Train testParam0 = new Train();
+            TrainDrawingInfo testParam0 = new TrainDrawingInfo { Train = new Train() };
             TimeOfDay testParam1 = new TimeOfDay(_rnd.Next(86400));
             ArrivalDepartureOptions testParam2 = (ArrivalDepartureOptions)(_rnd.Next(3) + 1);
             double testParam3 = _rnd.NextDouble();
@@ -67,7 +81,7 @@ namespace Timetabler.Data.Tests.Unit.Display
         [TestMethod]
         public void VertexInformationClassConstructorSetsYPropertyToValueOfFifthParameter()
         {
-            Train testParam0 = new Train();
+            TrainDrawingInfo testParam0 = new TrainDrawingInfo { Train = new Train() };
             TimeOfDay testParam1 = new TimeOfDay(_rnd.Next(86400));
             ArrivalDepartureOptions testParam2 = (ArrivalDepartureOptions)(_rnd.Next(3) + 1);
             double testParam3 = _rnd.NextDouble();

--- a/Timetabler.Data.Tests.Unit/DocumentOptionsUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/DocumentOptionsUnitTests.cs
@@ -1,13 +1,14 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using Tests.Utility.Extensions;
+using Tests.Utility.Providers;
 
 namespace Timetabler.Data.Tests.Unit
 {
     [TestClass]
     public class DocumentOptionsUnitTests
     {
-        private static Random _rnd = new Random();
+        private static Random _rnd = RandomProvider.Default;
 
         private DocumentOptions GetDocumentOptions()
         {

--- a/Timetabler.Data.Tests.Unit/DocumentOptionsUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/DocumentOptionsUnitTests.cs
@@ -9,10 +9,26 @@ namespace Timetabler.Data.Tests.Unit
     {
         private static Random _rnd = new Random();
 
+        private DocumentOptions GetDocumentOptions()
+        {
+            return GetDocumentOptions(_rnd.NextBoolean() ? ClockType.TwelveHourClock : ClockType.TwentyFourHourClock);
+        }
+
+        private DocumentOptions GetDocumentOptions(ClockType clockType)
+        {
+            return new DocumentOptions
+            {
+                ClockType = clockType,
+                DisplayTrainLabelsOnGraphs = _rnd.NextBoolean(),
+                GraphEditStyle = _rnd.NextBoolean() ? GraphEditStyle.Free : GraphEditStyle.PreserveSectionTimes,
+            };
+        }
+
+
         [TestMethod]
         public void DocumentOptionsClassFormattingStringsPropertyReturnsCorrectValuesIfClockTypeIsTwelveHourClock()
         {
-            DocumentOptions testObject = new DocumentOptions { ClockType = ClockType.TwelveHourClock, DisplayTrainLabelsOnGraphs = _rnd.NextBoolean() };
+            DocumentOptions testObject = GetDocumentOptions(ClockType.TwelveHourClock);
 
             TimeDisplayFormattingStrings testOutput = testObject.FormattingStrings;
 
@@ -26,7 +42,7 @@ namespace Timetabler.Data.Tests.Unit
         [TestMethod]
         public void DocumentOptionsClassFormattingStringsPropertyReturnsCorrectValuesIfClockTypeIsTwentyFourHourClock()
         {
-            DocumentOptions testObject = new DocumentOptions { ClockType = ClockType.TwentyFourHourClock, DisplayTrainLabelsOnGraphs = _rnd.NextBoolean() };
+            DocumentOptions testObject = GetDocumentOptions(ClockType.TwentyFourHourClock);
 
             TimeDisplayFormattingStrings testOutput = testObject.FormattingStrings;
 
@@ -40,7 +56,7 @@ namespace Timetabler.Data.Tests.Unit
         [TestMethod]
         public void DocumentOptionsClassClockTypePropertySetMethodUpdatesPropertiesOfFormattingStringsObjectIfClockTypeIsSetToTwentyFourHourClock()
         {
-            DocumentOptions testObject = new DocumentOptions { ClockType = ClockType.TwelveHourClock, DisplayTrainLabelsOnGraphs = _rnd.NextBoolean() };
+            DocumentOptions testObject = GetDocumentOptions(ClockType.TwelveHourClock);
 
             TimeDisplayFormattingStrings testOutput = testObject.FormattingStrings;
             testObject.ClockType = ClockType.TwentyFourHourClock;
@@ -55,7 +71,7 @@ namespace Timetabler.Data.Tests.Unit
         [TestMethod]
         public void DocumentOptionsClassClockTypePropertySetMethodUpdatesPropertiesOfFormattingStringsObjectIfClockTypeIsSetToTwelverHourClock()
         {
-            DocumentOptions testObject = new DocumentOptions { ClockType = ClockType.TwentyFourHourClock, DisplayTrainLabelsOnGraphs = _rnd.NextBoolean() };
+            DocumentOptions testObject = GetDocumentOptions(ClockType.TwentyFourHourClock);
 
             TimeDisplayFormattingStrings testOutput = testObject.FormattingStrings;
             testObject.ClockType = ClockType.TwelveHourClock;
@@ -70,11 +86,7 @@ namespace Timetabler.Data.Tests.Unit
         [TestMethod]
         public void DocumentOptionsClassCopyMethodReturnsNewObject()
         {
-            DocumentOptions testObject = new DocumentOptions
-            {
-                ClockType = _rnd.NextBoolean() ? ClockType.TwelveHourClock : ClockType.TwentyFourHourClock,
-                DisplayTrainLabelsOnGraphs = _rnd.NextBoolean()
-            };
+            DocumentOptions testObject = GetDocumentOptions();
 
             DocumentOptions testOutput = testObject.Copy();
 
@@ -84,11 +96,7 @@ namespace Timetabler.Data.Tests.Unit
         [TestMethod]
         public void DocumentOptionsClassCopyMethodReturnsNewObjectWithCorrectClockTypeProperty()
         {
-            DocumentOptions testObject = new DocumentOptions
-            {
-                ClockType = _rnd.NextBoolean() ? ClockType.TwelveHourClock : ClockType.TwentyFourHourClock,
-                DisplayTrainLabelsOnGraphs = _rnd.NextBoolean()
-            };
+            DocumentOptions testObject = GetDocumentOptions();
 
             DocumentOptions testOutput = testObject.Copy();
 
@@ -98,11 +106,7 @@ namespace Timetabler.Data.Tests.Unit
         [TestMethod]
         public void DocumentOptionsClassCopyMethodReturnsNewObjectWithCorrectDisplayTrainLabelsOnGraphsProperty()
         {
-            DocumentOptions testObject = new DocumentOptions
-            {
-                ClockType = _rnd.NextBoolean() ? ClockType.TwelveHourClock : ClockType.TwentyFourHourClock,
-                DisplayTrainLabelsOnGraphs = _rnd.NextBoolean()
-            };
+            DocumentOptions testObject = GetDocumentOptions();
 
             DocumentOptions testOutput = testObject.Copy();
 
@@ -112,11 +116,7 @@ namespace Timetabler.Data.Tests.Unit
         [TestMethod]
         public void DocumentOptionsClassCopyMethodReturnsNewObjectWithCorrectFormattingStringsPropertiesIfClockTypeIsTwelveHourClock()
         {
-            DocumentOptions testObject = new DocumentOptions
-            {
-                ClockType = ClockType.TwelveHourClock,
-                DisplayTrainLabelsOnGraphs = _rnd.NextBoolean()
-            };
+            DocumentOptions testObject = GetDocumentOptions(ClockType.TwelveHourClock);
 
             TimeDisplayFormattingStrings testOutput = testObject.Copy().FormattingStrings;
 
@@ -130,11 +130,7 @@ namespace Timetabler.Data.Tests.Unit
         [TestMethod]
         public void DocumentOptionsClassCopyMethodReturnsNewObjectWithCorrectFormattingStringsPropertiesIfClockTypeIsTwentyFourHourClock()
         {
-            DocumentOptions testObject = new DocumentOptions
-            {
-                ClockType = ClockType.TwentyFourHourClock,
-                DisplayTrainLabelsOnGraphs = _rnd.NextBoolean()
-            };
+            DocumentOptions testObject = GetDocumentOptions(ClockType.TwentyFourHourClock);
 
             TimeDisplayFormattingStrings testOutput = testObject.Copy().FormattingStrings;
 
@@ -143,6 +139,27 @@ namespace Timetabler.Data.Tests.Unit
             Assert.AreEqual("HH", testOutput.Hours);
             Assert.AreEqual("mmf", testOutput.Minutes);
             Assert.AreEqual("HH:mmf", testOutput.Tooltip);
+        }
+
+        [TestMethod]
+        public void DocumentOptionsClassCopyMethodReturnsNewObjectWithCorrectGraphEditStyleProperty()
+        {
+            DocumentOptions testObject = GetDocumentOptions();
+
+            DocumentOptions testOutput = testObject.Copy();
+
+            Assert.AreEqual(testObject.GraphEditStyle, testOutput.GraphEditStyle);
+        }
+
+        [TestMethod]
+        public void DocumentOptionsClassCopyToMethodOverwritesGraphEditStyleProperty()
+        {
+            DocumentOptions testObject = GetDocumentOptions();
+            DocumentOptions target = GetDocumentOptions();
+
+            testObject.CopyTo(target);
+
+            Assert.AreEqual(testObject.GraphEditStyle, target.GraphEditStyle);
         }
     }
 }

--- a/Timetabler.Data.Tests.Unit/Extensions/IEnumerableExtensionsUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/Extensions/IEnumerableExtensionsUnitTests.cs
@@ -1,0 +1,113 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Timetabler.CoreData;
+using Timetabler.Data.Display;
+using Timetabler.Data.Display.Comparers;
+using Timetabler.Data.Extensions;
+
+namespace Timetabler.Data.Tests.Unit.Extensions
+{
+    [TestClass]
+    public class IEnumerableExtensionsUnitTests
+    {
+        private static Random _rnd = new Random();
+
+        [TestMethod]
+        public void IEnumerableExtensionsClassLaterThanMethodReturnsCorrectNumberOfItems()
+        {
+            int listLen = _rnd.Next(100) + 2;
+            List<VertexInformation> rawData = new List<VertexInformation>(listLen);
+            List<VertexInformation> sortedData = new List<VertexInformation>(listLen);
+            for (int i = 0; i < listLen; ++i)
+            {
+                VertexInformation vi = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
+                rawData.Add(vi);
+                sortedData.Add(vi);
+            }
+            sortedData.Sort(new VertexInformationTimeBasedComparer());
+            int cutIdx = _rnd.Next(rawData.Count);
+            VertexInformation cut = sortedData[cutIdx];
+
+            List<VertexInformation> testOutput = rawData.LaterThan(cut).ToList();
+
+            Assert.AreEqual(rawData.Count - cutIdx, testOutput.Count);
+        }
+
+        [TestMethod]
+        public void IEnumerableExtensionsClassLaterThanMethodReturnsCorrectItems()
+        {
+            int listLen = _rnd.Next(100) + 2;
+            List<VertexInformation> rawData = new List<VertexInformation>(listLen);
+            List<VertexInformation> sortedData = new List<VertexInformation>(listLen);
+            for (int i = 0; i < listLen; ++i)
+            {
+                VertexInformation vi = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
+                rawData.Add(vi);
+                sortedData.Add(vi);
+            }
+            sortedData.Sort(new VertexInformationTimeBasedComparer());
+            int cutIdx = _rnd.Next(rawData.Count);
+            VertexInformation cut = sortedData[cutIdx];
+
+            List<VertexInformation> testOutput = rawData.LaterThan(cut).ToList();
+
+            foreach (VertexInformation filtered in testOutput)
+            {
+                Assert.IsTrue(filtered.Time >= cut.Time);
+                Assert.IsTrue(rawData.Contains(filtered));
+                rawData.Remove(filtered);
+            }
+        }
+
+        [TestMethod]
+        public void IEnumerableExtensionsClassEarlierThanMethodReturnsCorrectNumberOfItems()
+        {
+            int listLen = _rnd.Next(100) + 2;
+            List<VertexInformation> rawData = new List<VertexInformation>(listLen);
+            List<VertexInformation> sortedData = new List<VertexInformation>(listLen);
+            for (int i = 0; i < listLen; ++i)
+            {
+                VertexInformation vi = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
+                rawData.Add(vi);
+                sortedData.Add(vi);
+            }
+            sortedData.Sort(new VertexInformationTimeBasedComparer());
+            int cutIdx = _rnd.Next(rawData.Count);
+            VertexInformation cut = sortedData[cutIdx];
+
+            List<VertexInformation> testOutput = rawData.EarlierThan(cut).ToList();
+
+            Assert.AreEqual(cutIdx + 1, testOutput.Count);
+        }
+
+        [TestMethod]
+        public void IEnumerableExtensionsClassEarlierThanMethodReturnsCorrectItems()
+        {
+            int listLen = _rnd.Next(100) + 2;
+            List<VertexInformation> rawData = new List<VertexInformation>(listLen);
+            List<VertexInformation> sortedData = new List<VertexInformation>(listLen);
+            for (int i = 0; i < listLen; ++i)
+            {
+                VertexInformation vi = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
+                rawData.Add(vi);
+                sortedData.Add(vi);
+            }
+            sortedData.Sort(new VertexInformationTimeBasedComparer());
+            int cutIdx = _rnd.Next(rawData.Count);
+            VertexInformation cut = sortedData[cutIdx];
+
+            List<VertexInformation> testOutput = rawData.EarlierThan(cut).ToList();
+
+            foreach (VertexInformation filtered in testOutput)
+            {
+                Assert.IsTrue(filtered.Time <= cut.Time);
+                Assert.IsTrue(rawData.Contains(filtered));
+                rawData.Remove(filtered);
+            }
+        }
+    }
+}

--- a/Timetabler.Data.Tests.Unit/Extensions/IEnumerableExtensionsUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/Extensions/IEnumerableExtensionsUnitTests.cs
@@ -24,7 +24,8 @@ namespace Timetabler.Data.Tests.Unit.Extensions
             List<VertexInformation> sortedData = new List<VertexInformation>(listLen);
             for (int i = 0; i < listLen; ++i)
             {
-                VertexInformation vi = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
+                VertexInformation vi = new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), 
+                    _rnd.NextDouble());
                 rawData.Add(vi);
                 sortedData.Add(vi);
             }
@@ -45,7 +46,8 @@ namespace Timetabler.Data.Tests.Unit.Extensions
             List<VertexInformation> sortedData = new List<VertexInformation>(listLen);
             for (int i = 0; i < listLen; ++i)
             {
-                VertexInformation vi = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
+                VertexInformation vi = new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), 
+                    _rnd.NextDouble());
                 rawData.Add(vi);
                 sortedData.Add(vi);
             }
@@ -71,7 +73,8 @@ namespace Timetabler.Data.Tests.Unit.Extensions
             List<VertexInformation> sortedData = new List<VertexInformation>(listLen);
             for (int i = 0; i < listLen; ++i)
             {
-                VertexInformation vi = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
+                VertexInformation vi = new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), 
+                    _rnd.NextDouble());
                 rawData.Add(vi);
                 sortedData.Add(vi);
             }
@@ -92,7 +95,8 @@ namespace Timetabler.Data.Tests.Unit.Extensions
             List<VertexInformation> sortedData = new List<VertexInformation>(listLen);
             for (int i = 0; i < listLen; ++i)
             {
-                VertexInformation vi = new VertexInformation(new Train(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), _rnd.NextDouble());
+                VertexInformation vi = new VertexInformation(new TrainDrawingInfo(), new TimeOfDay(_rnd.Next(86400)), (ArrivalDepartureOptions)(_rnd.Next(3) + 1), _rnd.NextDouble(), 
+                    _rnd.NextDouble());
                 rawData.Add(vi);
                 sortedData.Add(vi);
             }

--- a/Timetabler.Data.Tests.Unit/Extensions/IEnumerableExtensionsUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/Extensions/IEnumerableExtensionsUnitTests.cs
@@ -2,8 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Tests.Utility.Providers;
 using Timetabler.CoreData;
 using Timetabler.Data.Display;
 using Timetabler.Data.Display.Comparers;
@@ -14,7 +13,7 @@ namespace Timetabler.Data.Tests.Unit.Extensions
     [TestClass]
     public class IEnumerableExtensionsUnitTests
     {
-        private static Random _rnd = new Random();
+        private static Random _rnd = RandomProvider.Default;
 
         [TestMethod]
         public void IEnumerableExtensionsClassLaterThanMethodReturnsCorrectNumberOfItems()

--- a/Timetabler.Data.Tests.Unit/TimeOfDayUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/TimeOfDayUnitTests.cs
@@ -1,12 +1,13 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using Tests.Utility.Providers;
 
 namespace Timetabler.Data.Tests.Unit
 {
     [TestClass]
     public class TimeOfDayUnitTests
     {
-        private static Random _rnd = new Random();
+        private static Random _rnd = RandomProvider.Default;
 
         [TestMethod]
         public void TimeOfDayClassConstructorWithDoubleParameterReturnsTimeOfDayWithCorrectValue()

--- a/Timetabler.Data.Tests.Unit/TimeOfDayUnitTests.cs
+++ b/Timetabler.Data.Tests.Unit/TimeOfDayUnitTests.cs
@@ -18,5 +18,109 @@ namespace Timetabler.Data.Tests.Unit
 
             Assert.AreEqual(testValue, testOutput.AbsoluteSeconds);
         }
+
+        [TestMethod]
+        public void TimeOfDayClassSubtractOperatorWithTimeOfDayAndTimeOfDayParameterReturnsTimeSpanWithCorrectValueIfFirstParameterIsBeforeSecondParameter()
+        {
+            int testSeconds0 = _rnd.Next(86399);
+            int testSeconds1 = _rnd.Next(86400 - testSeconds0) + testSeconds0 + 1;
+            TimeOfDay testValue0 = new TimeOfDay(testSeconds0);
+            TimeOfDay testValue1 = new TimeOfDay(testSeconds1);
+
+            TimeSpan testOutput = testValue1 - testValue0;
+
+            Assert.AreEqual(testSeconds1 - testSeconds0, (int)testOutput.TotalSeconds);
+        }
+
+        [TestMethod]
+        public void TimeOfDayClassSubtractOperatorWithTimeOfDayAndTimeOfDayParameterReturnsTimeSpanWithCorrectValueIfFirstParameterIsAfterSecondParameter()
+        {
+            int testSeconds1 = _rnd.Next(86399);
+            int testSeconds0 = _rnd.Next(86400 - testSeconds1) + testSeconds1 + 1;
+            TimeOfDay testValue0 = new TimeOfDay(testSeconds0);
+            TimeOfDay testValue1 = new TimeOfDay(testSeconds1);
+
+            TimeSpan testOutput = testValue1 - testValue0;
+
+            Assert.AreEqual(testSeconds1 - testSeconds0, (int)testOutput.TotalSeconds);
+        }
+
+        [TestMethod]
+        public void TimeOfDayClassSubtractOperatorWithTimeOfDayAndTimeSpanParameterReturnsTimeSpanWithCorrectValueIfFirstParameterIsBeforeSecondParameter()
+        {
+            int testSeconds0 = _rnd.Next(86399);
+            int testSeconds1 = _rnd.Next(86400 - testSeconds0) + testSeconds0 + 1;
+            TimeSpan testValue0 = TimeSpan.FromSeconds(testSeconds0);
+            TimeOfDay testValue1 = new TimeOfDay(testSeconds1);
+
+            TimeSpan testOutput = testValue1 - testValue0;
+
+            Assert.AreEqual(testSeconds1 - testSeconds0, (int)testOutput.TotalSeconds);
+        }
+
+        [TestMethod]
+        public void TimeOfDayClassSubtractOperatorWithTimeOfDayAndTimeSpanParameterReturnsTimeSpanWithCorrectValueIfFirstParameterIsAfterSecondParameter()
+        {
+            int testSeconds1 = _rnd.Next(86399);
+            int testSeconds0 = _rnd.Next(86400 - testSeconds1) + testSeconds1 + 1;
+            TimeSpan testValue0 = TimeSpan.FromSeconds(testSeconds0);
+            TimeOfDay testValue1 = new TimeOfDay(testSeconds1);
+
+            TimeSpan testOutput = testValue1 - testValue0;
+
+            Assert.AreEqual(testSeconds1 - testSeconds0, (int)testOutput.TotalSeconds);
+        }
+
+        [TestMethod]
+        public void TimeOfDayClassSubtractOperatorWithTimeSpanAndTimeOfDayParameterReturnsTimeSpanWithCorrectValueIfFirstParameterIsBeforeSecondParameter()
+        {
+            int testSeconds0 = _rnd.Next(86399);
+            int testSeconds1 = _rnd.Next(86400 - testSeconds0) + testSeconds0 + 1;
+            TimeOfDay testValue0 = new TimeOfDay(testSeconds0);
+            TimeSpan testValue1 = TimeSpan.FromSeconds(testSeconds1);
+
+            TimeSpan testOutput = testValue1 - testValue0;
+
+            Assert.AreEqual(testSeconds1 - testSeconds0, (int)testOutput.TotalSeconds);
+        }
+
+        [TestMethod]
+        public void TimeOfDayClassSubtractOperatorWithTimeSpanAndTimeOfDayParameterReturnsTimeSpanWithCorrectValueIfFirstParameterIsAfterSecondParameter()
+        {
+            int testSeconds1 = _rnd.Next(86399);
+            int testSeconds0 = _rnd.Next(86400 - testSeconds1) + testSeconds1 + 1;
+            TimeOfDay testValue0 = new TimeOfDay(testSeconds0);
+            TimeSpan testValue1 = TimeSpan.FromSeconds(testSeconds1);
+
+            TimeSpan testOutput = testValue1 - testValue0;
+
+            Assert.AreEqual(testSeconds1 - testSeconds0, (int)testOutput.TotalSeconds);
+        }
+
+        [TestMethod]
+        public void TimeOfDayClassAddOperatorWithTimeOfDayAndTimeSpanParametersReturnsTimeOfDayWithCorrectValueIfResultDoesNotCrossMidnight()
+        {
+            int testSeconds0 = _rnd.Next(86398);
+            int testSeconds1 = _rnd.Next(86399 - testSeconds0) + testSeconds0;
+            TimeOfDay testValue0 = new TimeOfDay(testSeconds0);
+            TimeSpan testValue1 = TimeSpan.FromSeconds(testSeconds1);
+
+            TimeOfDay testOutput = testValue0 + testValue1;
+
+            Assert.AreEqual(testSeconds0 + testSeconds1, testOutput.AbsoluteSeconds);
+        }
+
+        [TestMethod]
+        public void TimeOfDayClassAddOperatorWithTimeSpanAndTimeOfDayParametersReturnsTimeOfDayWithCorrectValueIfResultDoesNotCrossMidnight()
+        {
+            int testSeconds0 = _rnd.Next(86398);
+            int testSeconds1 = _rnd.Next(86399 - testSeconds0) + testSeconds0;
+            TimeSpan testValue0 = TimeSpan.FromSeconds(testSeconds0);
+            TimeOfDay testValue1 = new TimeOfDay(testSeconds1);
+
+            TimeOfDay testOutput = testValue0 + testValue1;
+
+            Assert.AreEqual(testSeconds0 + testSeconds1, testOutput.AbsoluteSeconds);
+        }
     }
 }

--- a/Timetabler.Data.Tests.Unit/Timetabler.Data.Tests.Unit.csproj
+++ b/Timetabler.Data.Tests.Unit/Timetabler.Data.Tests.Unit.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Display\FootnoteDisplayModelUnitTests.cs" />
     <Compile Include="Display\GenericEntryModelUnitTests.cs" />
     <Compile Include="Display\LineCoordinatesUnitTests.cs" />
+    <Compile Include="Display\TrainDrawingInfoUnitTests.cs" />
     <Compile Include="Display\TrainGraphModelUnitTests.cs" />
     <Compile Include="Display\TrainLocationTimeModelUnitTests.cs" />
     <Compile Include="Display\TrainSegmentModelUnitTests.cs" />

--- a/Timetabler.Data.Tests.Unit/Timetabler.Data.Tests.Unit.csproj
+++ b/Timetabler.Data.Tests.Unit/Timetabler.Data.Tests.Unit.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Display\TrainSegmentModelUnitTests.cs" />
     <Compile Include="Display\VertexInformationUnitTests.cs" />
     <Compile Include="DocumentOptionsUnitTests.cs" />
+    <Compile Include="Extensions\IEnumerableExtensionsUnitTests.cs" />
     <Compile Include="NoteUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SignalboxUnitTests.cs" />

--- a/Timetabler.Data.Tests.Unit/Timetabler.Data.Tests.Unit.csproj
+++ b/Timetabler.Data.Tests.Unit/Timetabler.Data.Tests.Unit.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Display\FootnoteDisplayModelUnitTests.cs" />
     <Compile Include="Display\GenericEntryModelUnitTests.cs" />
     <Compile Include="Display\LineCoordinatesUnitTests.cs" />
+    <Compile Include="Display\TrainGraphModelUnitTests.cs" />
     <Compile Include="Display\TrainLocationTimeModelUnitTests.cs" />
     <Compile Include="Display\TrainSegmentModelUnitTests.cs" />
     <Compile Include="Display\VertexInformationUnitTests.cs" />

--- a/Timetabler.Data.Tests.Unit/Timetabler.Data.Tests.Unit.csproj
+++ b/Timetabler.Data.Tests.Unit/Timetabler.Data.Tests.Unit.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Collections\SignalboxCollectionUnitTests.cs" />
     <Compile Include="Collections\TrainSegmentModelCollectionUnitTests.cs" />
     <Compile Include="Comparers\LocationDisplayModelComparerUnitTests.cs" />
+    <Compile Include="Comparers\VertexInformationTimeBasedComparerUnitTests.cs" />
     <Compile Include="Display\FootnoteDisplayModelUnitTests.cs" />
     <Compile Include="Display\GenericEntryModelUnitTests.cs" />
     <Compile Include="Display\LineCoordinatesUnitTests.cs" />

--- a/Timetabler.Data/Comparers/LocationDisplayModelComparer.cs
+++ b/Timetabler.Data/Comparers/LocationDisplayModelComparer.cs
@@ -9,8 +9,8 @@ namespace Timetabler.Data.Comparers
     /// </summary>
     public class LocationDisplayModelComparer : IComparer<LocationDisplayModel>
     {
-        private int xBeforeY = -1;
-        private int yBeforeX = 1;
+        private int xBeforeY;
+        private int yBeforeX;
         private Direction _direction;
 
         /// <summary>

--- a/Timetabler.Data/Display/Comparers/VertexInformationTimeBasedComparer.cs
+++ b/Timetabler.Data/Display/Comparers/VertexInformationTimeBasedComparer.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+
+namespace Timetabler.Data.Display.Comparers
+{
+    /// <summary>
+    /// An <see cref="IComparer{VertexInformation}" /> implementation which compares based on the <see cref="VertexInformation.Time" /> property of each object.
+    /// </summary>
+    public class VertexInformationTimeBasedComparer : IComparer<VertexInformation>
+    {
+        /// <summary>
+        /// Returns a comparison result based on the <see cref="VertexInformation.Time" /> property of the x and y parameters.
+        /// </summary>
+        /// <param name="x">A <see cref="VertexInformation" /> instance.</param>
+        /// <param name="y">A <see cref="VertexInformation" /> instance.</param>
+        /// <returns>A value of -1, 0 or 1 according to whether the first parameter is earlier, the same time as, or later than the second.</returns>
+        public int Compare(VertexInformation x, VertexInformation y)
+        {
+            if (x?.Time == null)
+            {
+                return y == null ? 0 : -1;
+            }
+            if (y?.Time == null)
+            {
+                return 1;
+            }
+            return x.Time.CompareTo(y.Time);
+        }
+    }
+}

--- a/Timetabler.Data/Display/Comparers/VertexInformationTimeBasedComparer.cs
+++ b/Timetabler.Data/Display/Comparers/VertexInformationTimeBasedComparer.cs
@@ -17,7 +17,7 @@ namespace Timetabler.Data.Display.Comparers
         {
             if (x?.Time == null)
             {
-                return y == null ? 0 : -1;
+                return y?.Time == null ? 0 : -1;
             }
             if (y?.Time == null)
             {

--- a/Timetabler.Data/Display/TrainDrawingInfo.cs
+++ b/Timetabler.Data/Display/TrainDrawingInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace Timetabler.Data.Display
 {
@@ -25,14 +26,25 @@ namespace Timetabler.Data.Display
         /// <summary>
         /// List of lines to draw to display this train.
         /// </summary>
-        public List<LineCoordinates> LineVertexes { get; set; }
+        public List<LineCoordinates> Lines { get; set; }
+
+        /// <summary>
+        /// An enumeration of all of the vertexes associated with the <see cref="Lines" /> property.
+        /// </summary>
+        public IEnumerable<VertexInformation> LineVertexes
+        {
+            get
+            {
+                return Lines.Select(i => i.Vertex1).Union(Lines.Select(i => i.Vertex2)).Distinct();
+            }
+        }
 
         /// <summary>
         /// Default constructor.
         /// </summary>
         public TrainDrawingInfo()
         {
-            LineVertexes = new List<LineCoordinates>();
+            Lines = new List<LineCoordinates>();
         }
     }
 }

--- a/Timetabler.Data/Display/TrainGraphModel.cs
+++ b/Timetabler.Data/Display/TrainGraphModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Timetabler.Data.Collections;
 using Timetabler.Data.Events;
@@ -28,9 +29,29 @@ namespace Timetabler.Data.Display
         public LocationCollection LocationList { get; set; }
 
         /// <summary>
+        /// Copy the values of relevant properties from a <see cref="DocumentOptions" /> instance.
+        /// </summary>
+        /// <param name="source">The object to copy the properties from.</param>
+        public void SetPropertiesFromDocumentOptions(DocumentOptions source)
+        {
+            if (source == null)
+            {
+                return;
+            }
+            DisplayTrainLabels = source.DisplayTrainLabelsOnGraphs;
+            GraphEditStyle = source.GraphEditStyle;
+            TooltipFormattingString = source.FormattingStrings.Tooltip;
+        }
+
+        /// <summary>
         /// Whether or not to display train labels on the train graph.
         /// </summary>
         public bool DisplayTrainLabels { get; set; }
+
+        /// <summary>
+        /// How to behave when dragging timing points
+        /// </summary>
+        public GraphEditStyle GraphEditStyle { get; set; }
 
         /// <summary>
         /// The format string to use when converting times to strings to display in tooltips.

--- a/Timetabler.Data/Display/TrainGraphModel.cs
+++ b/Timetabler.Data/Display/TrainGraphModel.cs
@@ -206,26 +206,26 @@ namespace Timetabler.Data.Display
                     if (train.TrainTimes[i]?.ArrivalTime?.Time != null && train.TrainTimes[i]?.DepartureTime?.Time != null)
                     {
                         double locationCoordinate = _locationCoordinates[train.TrainTimes[i].Location.Id];
-                        tdi.LineVertexes.Add(new LineCoordinates(
-                            new VertexInformation(train, train.TrainTimes[i].ArrivalTime.Time, ArrivalDepartureOptions.Arrival, GetXPositionFromTime(train.TrainTimes[i].ArrivalTime.Time), 
+                        tdi.Lines.Add(new LineCoordinates(
+                            new VertexInformation(tdi, train.TrainTimes[i].ArrivalTime.Time, ArrivalDepartureOptions.Arrival, GetXPositionFromTime(train.TrainTimes[i].ArrivalTime.Time), 
                                 locationCoordinate), 
-                            new VertexInformation(train, train.TrainTimes[i].DepartureTime.Time, ArrivalDepartureOptions.Departure, GetXPositionFromTime(train.TrainTimes[i].DepartureTime.Time), 
+                            new VertexInformation(tdi, train.TrainTimes[i].DepartureTime.Time, ArrivalDepartureOptions.Departure, GetXPositionFromTime(train.TrainTimes[i].DepartureTime.Time), 
                                 locationCoordinate)));
                     }
                     if (i > 0 && train.TrainTimes[i - 1]?.DepartureTime?.Time != null)
                     {
                         VertexInformation startVertex = 
-                            new VertexInformation(train, train.TrainTimes[i - 1].DepartureTime.Time, ArrivalDepartureOptions.Departure, 
+                            new VertexInformation(tdi, train.TrainTimes[i - 1].DepartureTime.Time, ArrivalDepartureOptions.Departure, 
                                 GetXPositionFromTime(train.TrainTimes[i - 1].DepartureTime.Time), _locationCoordinates[train.TrainTimes[i - 1].Location.Id]);
                         double endY = _locationCoordinates[train.TrainTimes[i].Location.Id];
                         if (train.TrainTimes[i]?.ArrivalTime?.Time != null)
                         {
-                            tdi.LineVertexes.Add(new LineCoordinates(startVertex, new VertexInformation(train, train.TrainTimes[i].ArrivalTime.Time, ArrivalDepartureOptions.Arrival,
+                            tdi.Lines.Add(new LineCoordinates(startVertex, new VertexInformation(tdi, train.TrainTimes[i].ArrivalTime.Time, ArrivalDepartureOptions.Arrival,
                                 GetXPositionFromTime(train.TrainTimes[i].ArrivalTime.Time), endY)));
                         }
                         else if (train.TrainTimes[i]?.DepartureTime?.Time != null)
                         {
-                            tdi.LineVertexes.Add(new LineCoordinates(startVertex, new VertexInformation(train, train.TrainTimes[i].DepartureTime.Time, ArrivalDepartureOptions.Departure,
+                            tdi.Lines.Add(new LineCoordinates(startVertex, new VertexInformation(tdi, train.TrainTimes[i].DepartureTime.Time, ArrivalDepartureOptions.Departure,
                                 GetXPositionFromTime(train.TrainTimes[i].DepartureTime.Time), endY)));
                         }
                     }
@@ -235,7 +235,13 @@ namespace Timetabler.Data.Display
             }
         }
 
-        private double GetXPositionFromTime(TimeOfDay t)
+        /// <summary>
+        /// Convert a time of day to a relative X-position on the graph.  A position within the current bounds of the graph will be between 0 and 1; times of day outside the current
+        /// bounds of the graph may be less than 0 or greater than 1.
+        /// </summary>
+        /// <param name="t">The time of day to convert.</param>
+        /// <returns>The graph coordinate equivalent to the time of day.</returns>
+        public double GetXPositionFromTime(TimeOfDay t)
         {
             if (!_baseTimeSeconds.HasValue || !_maxTimeSeconds.HasValue)
             {

--- a/Timetabler.Data/Display/TrainGraphModel.cs
+++ b/Timetabler.Data/Display/TrainGraphModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Timetabler.CoreData;
 using Timetabler.Data.Collections;
 using Timetabler.Data.Events;
 
@@ -205,23 +206,26 @@ namespace Timetabler.Data.Display
                     if (train.TrainTimes[i]?.ArrivalTime?.Time != null && train.TrainTimes[i]?.DepartureTime?.Time != null)
                     {
                         double locationCoordinate = _locationCoordinates[train.TrainTimes[i].Location.Id];
-                        tdi.LineVertexes.Add(new LineCoordinates(new VertexInformation(train, train.TrainTimes[i].ArrivalTime.Time, GetXPositionFromTime(train.TrainTimes[i].ArrivalTime.Time), 
-                            locationCoordinate), new VertexInformation(train, train.TrainTimes[i].DepartureTime.Time, GetXPositionFromTime(train.TrainTimes[i].DepartureTime.Time), 
-                            locationCoordinate)));
+                        tdi.LineVertexes.Add(new LineCoordinates(
+                            new VertexInformation(train, train.TrainTimes[i].ArrivalTime.Time, ArrivalDepartureOptions.Arrival, GetXPositionFromTime(train.TrainTimes[i].ArrivalTime.Time), 
+                                locationCoordinate), 
+                            new VertexInformation(train, train.TrainTimes[i].DepartureTime.Time, ArrivalDepartureOptions.Departure, GetXPositionFromTime(train.TrainTimes[i].DepartureTime.Time), 
+                                locationCoordinate)));
                     }
                     if (i > 0 && train.TrainTimes[i - 1]?.DepartureTime?.Time != null)
                     {
-                        VertexInformation startVertex = new VertexInformation(train, train.TrainTimes[i - 1].DepartureTime.Time, GetXPositionFromTime(train.TrainTimes[i - 1].DepartureTime.Time),
-                            _locationCoordinates[train.TrainTimes[i - 1].Location.Id]);
+                        VertexInformation startVertex = 
+                            new VertexInformation(train, train.TrainTimes[i - 1].DepartureTime.Time, ArrivalDepartureOptions.Departure, 
+                                GetXPositionFromTime(train.TrainTimes[i - 1].DepartureTime.Time), _locationCoordinates[train.TrainTimes[i - 1].Location.Id]);
                         double endY = _locationCoordinates[train.TrainTimes[i].Location.Id];
                         if (train.TrainTimes[i]?.ArrivalTime?.Time != null)
                         {
-                            tdi.LineVertexes.Add(new LineCoordinates(startVertex, new VertexInformation(train, train.TrainTimes[i].ArrivalTime.Time, 
+                            tdi.LineVertexes.Add(new LineCoordinates(startVertex, new VertexInformation(train, train.TrainTimes[i].ArrivalTime.Time, ArrivalDepartureOptions.Arrival,
                                 GetXPositionFromTime(train.TrainTimes[i].ArrivalTime.Time), endY)));
                         }
                         else if (train.TrainTimes[i]?.DepartureTime?.Time != null)
                         {
-                            tdi.LineVertexes.Add(new LineCoordinates(startVertex, new VertexInformation(train, train.TrainTimes[i].DepartureTime.Time, 
+                            tdi.LineVertexes.Add(new LineCoordinates(startVertex, new VertexInformation(train, train.TrainTimes[i].DepartureTime.Time, ArrivalDepartureOptions.Departure,
                                 GetXPositionFromTime(train.TrainTimes[i].DepartureTime.Time), endY)));
                         }
                     }

--- a/Timetabler.Data/Display/VertexInformation.cs
+++ b/Timetabler.Data/Display/VertexInformation.cs
@@ -8,9 +8,20 @@ namespace Timetabler.Data.Display
     public class VertexInformation
     {
         /// <summary>
-        /// The train to which this applies.
+        /// The drawing info for the train to which this vertex applies.
         /// </summary>
-        public Train Train { get; set; }
+        public TrainDrawingInfo TrainDrawingInfo { get; set; }
+
+        /// <summary>
+        /// The train to which this vertex applies.
+        /// </summary>
+        public Train Train
+        {
+            get
+            {
+                return TrainDrawingInfo?.Train;
+            }
+        }
 
         /// <summary>
         /// The time of the vertex.
@@ -40,14 +51,14 @@ namespace Timetabler.Data.Display
         /// <summary>
         /// Constructor which sets properties.
         /// </summary>
-        /// <param name="t">The train to which this vertex belongs.</param>
+        /// <param name="tdi">The train drawing info to which this vertex belongs.</param>
         /// <param name="time">The time of day that the vertex represents.</param>
         /// <param name="arrivalDeparture">Whether the vertex represents an arrival time, a departure time, or both.</param>
         /// <param name="x">The X-coordinate of the vertex.</param>
         /// <param name="y">The Y-coordinate of the vertex.</param>
-        public VertexInformation(Train t, TimeOfDay time, ArrivalDepartureOptions arrivalDeparture, double x, double y)
+        public VertexInformation(TrainDrawingInfo tdi, TimeOfDay time, ArrivalDepartureOptions arrivalDeparture, double x, double y)
         {
-            Train = t;
+            TrainDrawingInfo = tdi;
             Time = time;
             ArrivalDeparture = arrivalDeparture;
             X = x;

--- a/Timetabler.Data/Display/VertexInformation.cs
+++ b/Timetabler.Data/Display/VertexInformation.cs
@@ -1,4 +1,6 @@
-﻿namespace Timetabler.Data.Display
+﻿using Timetabler.CoreData;
+
+namespace Timetabler.Data.Display
 {
     /// <summary>
     /// Represents a vertex on a train graph.
@@ -14,6 +16,11 @@
         /// The time of the vertex.
         /// </summary>
         public TimeOfDay Time { get; set; }
+
+        /// <summary>
+        /// Whether this vertex applies to arrivals, departures, or both.
+        /// </summary>
+        public ArrivalDepartureOptions ArrivalDeparture { get; set; }
 
         /// <summary>
         /// The X-position
@@ -35,12 +42,14 @@
         /// </summary>
         /// <param name="t">The train to which this vertex belongs.</param>
         /// <param name="time">The time of day that the vertex represents.</param>
+        /// <param name="arrivalDeparture">Whether the vertex represents an arrival time, a departure time, or both.</param>
         /// <param name="x">The X-coordinate of the vertex.</param>
         /// <param name="y">The Y-coordinate of the vertex.</param>
-        public VertexInformation(Train t, TimeOfDay time, double x, double y)
+        public VertexInformation(Train t, TimeOfDay time, ArrivalDepartureOptions arrivalDeparture, double x, double y)
         {
             Train = t;
             Time = time;
+            ArrivalDeparture = arrivalDeparture;
             X = x;
             Y = y;
         }

--- a/Timetabler.Data/DocumentOptions.cs
+++ b/Timetabler.Data/DocumentOptions.cs
@@ -29,6 +29,11 @@
         public bool DisplayTrainLabelsOnGraphs { get; set; }
 
         /// <summary>
+        /// How the train graph control should behave.
+        /// </summary>
+        public GraphEditStyle GraphEditStyle { get; set; }
+
+        /// <summary>
         /// The correct formatting strings to use for time output, given the current value of the <see cref="ClockType" /> property.  Note that subsequent calls to the get method of this property
         /// may return the same object.  That object's properties are tied to the this object's <see cref="ClockType" /> property and will change if the <see cref="ClockType" /> property 
         /// of this object is changed.
@@ -41,7 +46,7 @@
         /// <returns>A copy of this instance.</returns>
         public DocumentOptions Copy()
         {
-            return new DocumentOptions { ClockType = ClockType, DisplayTrainLabelsOnGraphs = DisplayTrainLabelsOnGraphs };
+            return new DocumentOptions { ClockType = ClockType, DisplayTrainLabelsOnGraphs = DisplayTrainLabelsOnGraphs, GraphEditStyle = GraphEditStyle };
         }
 
         /// <summary>
@@ -61,6 +66,7 @@
                 options.ClockType = ClockType;
             }
             options.DisplayTrainLabelsOnGraphs = DisplayTrainLabelsOnGraphs;
+            options.GraphEditStyle = GraphEditStyle;
         }
 
         /// <summary>

--- a/Timetabler.Data/Extensions/IEnumerableExtensions.cs
+++ b/Timetabler.Data/Extensions/IEnumerableExtensions.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Timetabler.Data.Display;
+
+namespace Timetabler.Data.Extensions
+{
+    /// <summary>
+    /// Extension methods for <see cref="IEnumerable{VertexInformation}" />.
+    /// </summary>
+    public static class IEnumerableExtensions
+    {
+        /// <summary>
+        /// Filters the items in an <see cref="IEnumerable{VertexInformation}" /> list according to whether their <see cref="VertexInformation.Time" /> property is later than (or the same as) that
+        /// of the parameter.
+        /// </summary>
+        /// <param name="items">The enumerable to filter.</param>
+        /// <param name="cut">The cutoff time.</param>
+        /// <returns>An enumerable whose items have a later time property than that of the cutoff parameter.</returns>
+        public static IEnumerable<VertexInformation> LaterThan(this IEnumerable<VertexInformation> items, VertexInformation cut)
+        {
+            if (cut?.Time == null)
+            {
+                return items;
+            }
+            return items.Where(i => i.Time != null && cut.Time <= i.Time);
+        }
+
+        /// <summary>
+        /// Filters the items in an <see cref="IEnumerable{VertexInformation}" /> list according to whether their <see cref="VertexInformation.Time" /> property is earlier than (or the same as) 
+        /// that of the parameter.
+        /// </summary>
+        /// <param name="items">The enumerable to filter.</param>
+        /// <param name="cut">The cutoff time.</param>
+        /// <returns>An enumerable whose items have an earlier time property than that of the cutoff parameter.</returns>
+        public static IEnumerable<VertexInformation> EarlierThan(this IEnumerable<VertexInformation> items, VertexInformation cut)
+        {
+            if (cut?.Time == null)
+            {
+                return items;
+            }
+            return items.Where(i => i.Time != null && cut.Time >= i.Time);
+        }
+    }
+}

--- a/Timetabler.Data/Extensions/IEnumerableExtensions.cs
+++ b/Timetabler.Data/Extensions/IEnumerableExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Timetabler.CoreData.Helpers;
 using Timetabler.Data.Display;
 
 namespace Timetabler.Data.Extensions
@@ -39,6 +40,17 @@ namespace Timetabler.Data.Extensions
                 return items;
             }
             return items.Where(i => i.Time != null && cut.Time >= i.Time);
+        }
+
+        /// <summary>
+        /// This method takes an <see cref="IEnumerable{VertexInformation}" /> parameter and projects the elements to return an enumeration of the Time property of each element.
+        /// Duplicates are removed from the enumeration, as the <see cref="VertexInformation" /> objects may well maintain references to the same underlying <see cref="TimeOfDay" /> objects
+        /// </summary>
+        /// <param name="items">An enumeration of <see cref="VertexInformation" /> instances.</param>
+        /// <returns>An enumeration of <see cref="TimeOfDay" /> objects referred to by the instances from the parameter.</returns>
+        public static IEnumerable<TimeOfDay> Times(this IEnumerable<VertexInformation> items)
+        {
+            return items.Select(v => v.Time).Distinct(ReferenceEqualityComparer.Default).Cast<TimeOfDay>();
         }
     }
 }

--- a/Timetabler.Data/Extensions/IEnumerableExtensions.cs
+++ b/Timetabler.Data/Extensions/IEnumerableExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Timetabler.CoreData.Helpers;
+using Timetabler.CoreData.Comparers;
 using Timetabler.Data.Display;
 
 namespace Timetabler.Data.Extensions

--- a/Timetabler.Data/GraphEditStyle.cs
+++ b/Timetabler.Data/GraphEditStyle.cs
@@ -1,0 +1,19 @@
+﻿namespace Timetabler.Data
+{
+    /// <summary>
+    /// The way in which the train graph control should behave when timing points are dragged.
+    /// </summary>
+    public enum GraphEditStyle
+    {
+        /// <summary>
+        /// Allow free editing - even if it makes trains appear to travel in time.
+        /// </summary>
+        Free = 0,
+
+        /// <summary>
+        /// Preserve section times - when a time is dragged forward in time, times in the future are also moved forward.  When a time is dragged backwards in time, times in the past
+        /// are moved backwards.
+        /// </summary>
+        PreserveSectionTimes = 1
+    }
+}

--- a/Timetabler.Data/TimeOfDay.cs
+++ b/Timetabler.Data/TimeOfDay.cs
@@ -493,6 +493,61 @@ namespace Timetabler.Data
         }
 
         /// <summary>
+        /// Returns a <see cref="TimeSpan" /> representing the time elapsed between the two parameters.
+        /// </summary>
+        /// <param name="t1"></param>
+        /// <param name="t2"></param>
+        /// <returns>A <see cref="TimeSpan" /> struct.</returns>
+        public static TimeSpan operator -(TimeOfDay t1, TimeOfDay t2)
+        {
+            return TimeSpan.FromSeconds(t1.AbsoluteSeconds - t2.AbsoluteSeconds);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="TimeSpan" /> representing the time elapsed between the two parameters.
+        /// </summary>
+        /// <param name="t1"></param>
+        /// <param name="t2"></param>
+        /// <returns>A <see cref="TimeSpan" /> struct.</returns>
+        public static TimeSpan operator -(TimeOfDay t1, TimeSpan t2)
+        {
+            return TimeSpan.FromSeconds(t1.AbsoluteSeconds - t2.TotalSeconds);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="TimeSpan" /> representing the time elapsed between the two parameters.
+        /// </summary>
+        /// <param name="t1"></param>
+        /// <param name="t2"></param>
+        /// <returns>A <see cref="TimeSpan" /> struct.</returns>
+        public static TimeSpan operator -(TimeSpan t1, TimeOfDay t2)
+        {
+            return TimeSpan.FromSeconds(t1.TotalSeconds - t2.AbsoluteSeconds);
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="TimeOfDay" /> object representing the time of day of the first parameter, plus the span of time of the second parameter.
+        /// </summary>
+        /// <param name="t1"></param>
+        /// <param name="t2"></param>
+        /// <returns>A new <see cref="TimeOfDay" /> instance.</returns>
+        public static TimeOfDay operator +(TimeOfDay t1, TimeSpan t2)
+        {
+            return new TimeOfDay(t1.AbsoluteSeconds + t2.TotalSeconds);
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="TimeOfDay" /> object representing the time of day of the second parameter, plus the span of time of the first parameter.
+        /// </summary>
+        /// <param name="t1"></param>
+        /// <param name="t2"></param>
+        /// <returns>A new <see cref="TimeOfDay" /> instance.</returns>
+        public static TimeOfDay operator +(TimeSpan t1, TimeOfDay t2)
+        {
+            return new TimeOfDay(t1.TotalSeconds + t2.AbsoluteSeconds);
+        }
+
+        /// <summary>
         /// Offsets a <see cref="TimeOfDay"/> by a given number of minutes.
         /// </summary>
         /// <param name="minutes">The number of minutes (positive or negative) to add to the current time.</param>

--- a/Timetabler.Data/Timetabler.Data.csproj
+++ b/Timetabler.Data/Timetabler.Data.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Events\TrainClassEventArgs.cs" />
     <Compile Include="Events\TrainSegmentModelEventArgs.cs" />
     <Compile Include="Events\TrainSegmentModelEventHandler.cs" />
+    <Compile Include="GraphEditStyle.cs" />
     <Compile Include="GraphTrainProperties.cs" />
     <Compile Include="HalfOfDay.cs" />
     <Compile Include="Interfaces\IExporter.cs" />

--- a/Timetabler.Data/Timetabler.Data.csproj
+++ b/Timetabler.Data/Timetabler.Data.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Comparers\LocationDisplayModelComparer.cs" />
     <Compile Include="Comparers\TrainSegmentModelComparer.cs" />
     <Compile Include="Direction.cs" />
+    <Compile Include="Display\Comparers\VertexInformationTimeBasedComparer.cs" />
     <Compile Include="Display\FootnoteDisplayModel.cs" />
     <Compile Include="Display\GenericEntryModel.cs" />
     <Compile Include="Display\GenericTimeModel.cs" />
@@ -101,6 +102,7 @@
     <Compile Include="Events\TrainClassEventArgs.cs" />
     <Compile Include="Events\TrainSegmentModelEventArgs.cs" />
     <Compile Include="Events\TrainSegmentModelEventHandler.cs" />
+    <Compile Include="Extensions\IEnumerableExtensions.cs" />
     <Compile Include="GraphEditStyle.cs" />
     <Compile Include="GraphTrainProperties.cs" />
     <Compile Include="HalfOfDay.cs" />

--- a/Timetabler.DataLoader.Tests.Unit/Load/DocumentOptionsModelExtensionsUnitTests.cs
+++ b/Timetabler.DataLoader.Tests.Unit/Load/DocumentOptionsModelExtensionsUnitTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Timetabler.CoreData;
 using Timetabler.Data;
 using Timetabler.DataLoader.Load;
 using Timetabler.XmlData;
@@ -26,6 +27,46 @@ namespace Timetabler.DataLoader.Tests.Unit.Load
             DocumentOptions resultObject = testObject.ToDocumentOptions();
 
             Assert.AreEqual(ClockType.TwentyFourHourClock, resultObject.ClockType);
+        }
+
+        [TestMethod]
+        public void DocumentOptionsModelExtensionsClassToDocumentOptionsMethodReturnsDocumentOptionsObjectWithCorrectGraphEditStylePropertyIfArgumentGraphEditStylePropertyEqualsFree()
+        {
+            DocumentOptionsModel testObject = new DocumentOptionsModel { GraphEditStyle = "Free" };
+
+            DocumentOptions resultObject = testObject.ToDocumentOptions();
+
+            Assert.AreEqual(GraphEditStyle.Free, resultObject.GraphEditStyle);
+        }
+
+        [TestMethod]
+        public void DocumentOptionsModelExtensionsClassToDocumentOptionsMethodReturnsDocumentOptionsObjectWithCorrectGraphEditStylePropertyIfArgumentGraphEditStylePropertyEqualsPreserveSectionTimes()
+        {
+            DocumentOptionsModel testObject = new DocumentOptionsModel { GraphEditStyle = "PreserveSectionTimes" };
+
+            DocumentOptions resultObject = testObject.ToDocumentOptions();
+
+            Assert.AreEqual(GraphEditStyle.PreserveSectionTimes, resultObject.GraphEditStyle);
+        }
+
+        [TestMethod]
+        public void DocumentOptionsModelExtensionsClassToDocumentOptionsMethodReturnsDocumentOptionsObjectWithGraphEditStylePropertyEqualToFreeIfArgumentGraphEditStylePropertyIsNull()
+        {
+            DocumentOptionsModel testObject = new DocumentOptionsModel { GraphEditStyle = null };
+
+            DocumentOptions resultObject = testObject.ToDocumentOptions();
+
+            Assert.AreEqual(GraphEditStyle.Free, resultObject.GraphEditStyle);
+        }
+
+        [TestMethod]
+        public void DocumentOptionsModelExtensionsClassToDocumentOptionsMethodReturnsDocumentOptionsObjectWithGraphEditStylePropertyEqualToFreeIfArgumentGraphEditStylePropertyIsEmptyString()
+        {
+            DocumentOptionsModel testObject = new DocumentOptionsModel { GraphEditStyle = "" };
+
+            DocumentOptions resultObject = testObject.ToDocumentOptions();
+
+            Assert.AreEqual(GraphEditStyle.Free, resultObject.GraphEditStyle);
         }
     }
 }

--- a/Timetabler.DataLoader.Tests.Unit/Save/DocumentOptionsExtensionsUnitTests.cs
+++ b/Timetabler.DataLoader.Tests.Unit/Save/DocumentOptionsExtensionsUnitTests.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Timetabler.CoreData;
+using Timetabler.Data;
+using Timetabler.DataLoader.Save;
+using Timetabler.XmlData;
+
+namespace Timetabler.DataLoader.Tests.Unit.Save
+{
+    [TestClass]
+    public class DocumentOptionsExtensionsUnitTests
+    {
+        [TestMethod]
+        public void DocumentOptionsExtensionsClassToDocumentOptionsModelMethodSetsGraphEditStylePropertyToCorrectValueIfArgumentGraphEditStylePropertyEqualsFree()
+        {
+            DocumentOptions testObject = new DocumentOptions { GraphEditStyle = GraphEditStyle.Free };
+
+            DocumentOptionsModel testOutput = testObject.ToDocumentOptionsModel();
+
+            Assert.AreEqual("Free", testOutput.GraphEditStyle);
+        }
+
+        [TestMethod]
+        public void DocumentOptionsExtensionsClassToDocumentOptionsModelMethodSetsGraphEditStylePropertyToCorrectValueIfArgumentGraphEditStylePropertyEqualsPreserveSectionTimes()
+        {
+            DocumentOptions testObject = new DocumentOptions { GraphEditStyle = GraphEditStyle.PreserveSectionTimes };
+
+            DocumentOptionsModel testOutput = testObject.ToDocumentOptionsModel();
+
+            Assert.AreEqual("PreserveSectionTimes", testOutput.GraphEditStyle);
+        }
+    }
+}

--- a/Timetabler.DataLoader.Tests.Unit/Timetabler.DataLoader.Tests.Unit.csproj
+++ b/Timetabler.DataLoader.Tests.Unit/Timetabler.DataLoader.Tests.Unit.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Load\TrainLocationTimeModelExtensionsUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Save\DocumentExportOptionsExtensionsUnitTests.cs" />
+    <Compile Include="Save\DocumentOptionsExtensionsUnitTests.cs" />
     <Compile Include="Save\LocationExtensionsUnitTests.cs" />
     <Compile Include="Save\TimetableDocumentExtensionsUnitTests.cs" />
   </ItemGroup>

--- a/Timetabler.DataLoader/Load/DocumentOptionsModelExtensions.cs
+++ b/Timetabler.DataLoader/Load/DocumentOptionsModelExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Timetabler.CoreData;
 using Timetabler.Data;
 using Timetabler.XmlData;
 
@@ -25,6 +26,12 @@ namespace Timetabler.DataLoader.Load
             if (Enum.TryParse(model.ClockTypeName, out ct))
             {
                 options.ClockType = ct;
+            }
+
+            GraphEditStyle ges;
+            if (Enum.TryParse(model.GraphEditStyle, out ges))
+            {
+                options.GraphEditStyle = ges;
             }
 
             return options;

--- a/Timetabler.DataLoader/Save/DocumentOptionsExtensions.cs
+++ b/Timetabler.DataLoader/Save/DocumentOptionsExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Timetabler.CoreData;
 using Timetabler.Data;
 using Timetabler.XmlData;
 
@@ -20,6 +21,7 @@ namespace Timetabler.DataLoader.Save
             {
                 ClockTypeName = Enum.GetName(typeof(ClockType), options.ClockType),
                 DisplayTrainLabelsOnGraphs = options.DisplayTrainLabelsOnGraphs,
+                GraphEditStyle = Enum.GetName(typeof(GraphEditStyle), options.GraphEditStyle),
             };
         }
     }

--- a/Timetabler.PdfExport/PdfExporter.cs
+++ b/Timetabler.PdfExport/PdfExporter.cs
@@ -272,7 +272,7 @@ namespace Timetabler.PdfExport
 
             foreach (TrainDrawingInfo info in trainGraphModel.GetTrainDrawingInformation())
             {
-                foreach (LineCoordinates lineData in info.LineVertexes)
+                foreach (LineCoordinates lineData in info.Lines)
                 {
                     _currentPage.PageGraphics.DrawLine(CoordinateHelper.Stretch(leftLimit, _currentPage.RightMarginPosition, lineData.Vertex1.X),
                         CoordinateHelper.Stretch(topLimit, bottomLimit, 1 - lineData.Vertex1.Y), CoordinateHelper.Stretch(leftLimit, _currentPage.RightMarginPosition, lineData.Vertex2.X),
@@ -282,7 +282,7 @@ namespace Timetabler.PdfExport
                 if (trainGraphModel.DisplayTrainLabels && !string.IsNullOrWhiteSpace(info.Headcode))
                 {
                     UniSize headcodeDimensions = _currentPage.PageGraphics.MeasureString(info.Headcode.Trim(), _plainBodyFont);
-                    LineCoordinates longestLine = info.LineVertexes[LineCoordinates.GetIndexOfLongestLine(info.LineVertexes)];
+                    LineCoordinates longestLine = info.Lines[LineCoordinates.GetIndexOfLongestLine(info.Lines)];
                     double llX1 = CoordinateHelper.Stretch(leftLimit, _currentPage.RightMarginPosition, longestLine.Vertex1.X);
                     double llX2 = CoordinateHelper.Stretch(leftLimit, _currentPage.RightMarginPosition, longestLine.Vertex2.X);
                     double llY1 = CoordinateHelper.Stretch(topLimit, bottomLimit, 1 - longestLine.Vertex1.Y);

--- a/Timetabler.XmlData/DocumentOptionsModel.cs
+++ b/Timetabler.XmlData/DocumentOptionsModel.cs
@@ -18,5 +18,11 @@ namespace Timetabler.XmlData
         /// </summary>
         [XmlElement]
         public bool? DisplayTrainLabelsOnGraphs { get; set; }
+
+        /// <summary>
+        /// How the train graph control should behave when the timetable is being edited.
+        /// </summary>
+        [XmlElement]
+        public string GraphEditStyle { get; set; }
     }
 }

--- a/Timetabler/Controls/TrainGraph.cs
+++ b/Timetabler/Controls/TrainGraph.cs
@@ -13,6 +13,8 @@ using Timetabler.Data.Display;
 using Timetabler.Extensions;
 using Timetabler.CoreData.Helpers;
 using NLog;
+using Timetabler.CoreData;
+using Timetabler.Data.Extensions;
 
 namespace Timetabler.Controls
 {
@@ -222,7 +224,7 @@ namespace Timetabler.Controls
             foreach (TrainDrawingInfo info in trainDrawingInfo)
             {
                 Pen trainPen = new Pen(info.Properties.Colour, info.Properties.Width) { DashStyle = info.Properties.DashStyle };
-                foreach (LineCoordinates lineData in info.LineVertexes)
+                foreach (LineCoordinates lineData in info.Lines)
                 {
                     DrawLine(e.Graphics, trainPen, lineData.Vertex1, lineData.Vertex2, leftLimit, MaximumXCoordinate, topLimit, bottomLimit, selectedTrainCoordinates);
                 }
@@ -230,7 +232,7 @@ namespace Timetabler.Controls
                 if (Model.DisplayTrainLabels && !string.IsNullOrWhiteSpace(info.Headcode))
                 {
                     SizeF headcodeDimensions = e.Graphics.MeasureString(info.Headcode.Trim(), TrainLabelFont);
-                    LineCoordinates longestLine = info.LineVertexes[LineCoordinates.GetIndexOfLongestLine(info.LineVertexes)];
+                    LineCoordinates longestLine = info.Lines[LineCoordinates.GetIndexOfLongestLine(info.Lines)];
                     float llX1 = CoordinateHelper.Stretch(leftLimit, MaximumXCoordinate, longestLine.Vertex1.X);
                     float llX2 = CoordinateHelper.Stretch(leftLimit, MaximumXCoordinate, longestLine.Vertex2.X);
                     float llY1 = CoordinateHelper.Stretch(topLimit, bottomLimit, 1 - longestLine.Vertex1.Y);
@@ -414,13 +416,64 @@ namespace Timetabler.Controls
         {
             if (InDragMode && _nearestVertex != null)
             {
-                double relativeX = CoordinateHelper.Unstretch(LocationAxisXCoordinate, MaximumXCoordinate, e.X - DragPointerOffset);
-                _nearestVertex.X = relativeX;
-                Model.GetTimeOfDayFromXPosition(relativeX).CopyTo(_nearestVertex.Time);
-                _nearestVertex.Train.RefreshTimingPointModels();
+                ProcessEndOfDrag(e.X);
                 Invalidate();
             }
             InDragMode = false;
+        }
+
+        private void ProcessEndOfDrag(int xCoord)
+        {
+            double relativeX = CoordinateHelper.Unstretch(LocationAxisXCoordinate, MaximumXCoordinate, xCoord - DragPointerOffset);
+            if (Model.GraphEditStyle == GraphEditStyle.Free)
+            {
+                _nearestVertex.X = relativeX;
+                Model.GetTimeOfDayFromXPosition(relativeX).CopyTo(_nearestVertex.Time);
+            }
+            else if (Model.GraphEditStyle == GraphEditStyle.PreserveSectionTimes)
+            {
+                TimeSpan timeOffset = Model.GetTimeOfDayFromXPosition(relativeX) - _nearestVertex.Time;
+
+                // Departure moved later
+                if ((_nearestVertex.ArrivalDeparture & ArrivalDepartureOptions.Departure) != 0 && timeOffset.TotalSeconds > 0)
+                {
+                    IEnumerable<VertexInformation> vertexes = _nearestVertex.TrainDrawingInfo.LineVertexes.LaterThan(_nearestVertex).ToList();
+                    foreach (TimeOfDay time in vertexes.Times())
+                    {
+                        (time + timeOffset).CopyTo(time);
+                    }
+                    foreach (VertexInformation vertex in vertexes)
+                    {
+                        vertex.X = Model.GetXPositionFromTime(vertex.Time);
+                    }
+                }
+                // Arrival moved earlier
+                else if ((_nearestVertex.ArrivalDeparture & ArrivalDepartureOptions.Arrival) != 0 && timeOffset.TotalSeconds < 0)
+                {
+                    IEnumerable<VertexInformation> vertexes = _nearestVertex.TrainDrawingInfo.LineVertexes.EarlierThan(_nearestVertex).ToList();
+                    foreach (TimeOfDay time in vertexes.Times())
+                    {
+                        (time + timeOffset).CopyTo(time);
+                    }
+                    foreach (VertexInformation vertex in vertexes)
+                    {
+                        vertex.X = Model.GetXPositionFromTime(vertex.Time);
+                    }
+                }
+                // Departure moved earlier or arrival moved later
+                else
+                {
+                    foreach (TimeOfDay time in _nearestVertex.TrainDrawingInfo.LineVertexes.Times())
+                    {
+                        (time + timeOffset).CopyTo(time);
+                    }
+                    foreach (VertexInformation vertex in _nearestVertex.TrainDrawingInfo.LineVertexes)
+                    {
+                        vertex.X = Model.GetXPositionFromTime(vertex.Time);
+                    }
+                }
+            }
+            _nearestVertex.Train.RefreshTimingPointModels();    
         }
     }
 }

--- a/Timetabler/Controls/TrainGraph.cs
+++ b/Timetabler/Controls/TrainGraph.cs
@@ -433,47 +433,37 @@ namespace Timetabler.Controls
             else if (Model.GraphEditStyle == GraphEditStyle.PreserveSectionTimes)
             {
                 TimeSpan timeOffset = Model.GetTimeOfDayFromXPosition(relativeX) - _nearestVertex.Time;
-
+                IList<VertexInformation> vertexes;
                 // Departure moved later
                 if ((_nearestVertex.ArrivalDeparture & ArrivalDepartureOptions.Departure) != 0 && timeOffset.TotalSeconds > 0)
                 {
-                    IEnumerable<VertexInformation> vertexes = _nearestVertex.TrainDrawingInfo.LineVertexes.LaterThan(_nearestVertex).ToList();
-                    foreach (TimeOfDay time in vertexes.Times())
-                    {
-                        (time + timeOffset).CopyTo(time);
-                    }
-                    foreach (VertexInformation vertex in vertexes)
-                    {
-                        vertex.X = Model.GetXPositionFromTime(vertex.Time);
-                    }
+                    vertexes = _nearestVertex.TrainDrawingInfo.LineVertexes.LaterThan(_nearestVertex).ToList();
                 }
                 // Arrival moved earlier
                 else if ((_nearestVertex.ArrivalDeparture & ArrivalDepartureOptions.Arrival) != 0 && timeOffset.TotalSeconds < 0)
                 {
-                    IEnumerable<VertexInformation> vertexes = _nearestVertex.TrainDrawingInfo.LineVertexes.EarlierThan(_nearestVertex).ToList();
-                    foreach (TimeOfDay time in vertexes.Times())
-                    {
-                        (time + timeOffset).CopyTo(time);
-                    }
-                    foreach (VertexInformation vertex in vertexes)
-                    {
-                        vertex.X = Model.GetXPositionFromTime(vertex.Time);
-                    }
+                    vertexes = _nearestVertex.TrainDrawingInfo.LineVertexes.EarlierThan(_nearestVertex).ToList();
                 }
                 // Departure moved earlier or arrival moved later
                 else
                 {
-                    foreach (TimeOfDay time in _nearestVertex.TrainDrawingInfo.LineVertexes.Times())
-                    {
-                        (time + timeOffset).CopyTo(time);
-                    }
-                    foreach (VertexInformation vertex in _nearestVertex.TrainDrawingInfo.LineVertexes)
-                    {
-                        vertex.X = Model.GetXPositionFromTime(vertex.Time);
-                    }
+                    vertexes = _nearestVertex.TrainDrawingInfo.LineVertexes.ToList();
                 }
+                ShiftVertexes(vertexes, timeOffset);
             }
             _nearestVertex.Train.RefreshTimingPointModels();    
+        }
+
+        private void ShiftVertexes(IList<VertexInformation> vertexes, TimeSpan timeOffset)
+        {
+            foreach (TimeOfDay time in vertexes.Times())
+            {
+                (time + timeOffset).CopyTo(time);
+            }
+            foreach (VertexInformation vertex in vertexes)
+            {
+                vertex.X = Model.GetXPositionFromTime(vertex.Time);
+            }
         }
     }
 }

--- a/Timetabler/DocumentOptionsEditForm.Designer.cs
+++ b/Timetabler/DocumentOptionsEditForm.Designer.cs
@@ -34,6 +34,8 @@
             this.label1 = new System.Windows.Forms.Label();
             this.cbClockType = new System.Windows.Forms.ComboBox();
             this.ckDisplayTrainLabelsOnGraphs = new System.Windows.Forms.CheckBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.cbGraphEditStyle = new System.Windows.Forms.ComboBox();
             this.SuspendLayout();
             // 
             // btnOk
@@ -70,12 +72,27 @@
             this.ckDisplayTrainLabelsOnGraphs.UseVisualStyleBackColor = true;
             this.ckDisplayTrainLabelsOnGraphs.CheckedChanged += new System.EventHandler(this.ckDisplayTrainLabelsOnGraphs_CheckedChanged);
             // 
+            // label2
+            // 
+            resources.ApplyResources(this.label2, "label2");
+            this.label2.Name = "label2";
+            // 
+            // cbGraphEditStyle
+            // 
+            this.cbGraphEditStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbGraphEditStyle.FormattingEnabled = true;
+            resources.ApplyResources(this.cbGraphEditStyle, "cbGraphEditStyle");
+            this.cbGraphEditStyle.Name = "cbGraphEditStyle";
+            this.cbGraphEditStyle.SelectedIndexChanged += new System.EventHandler(this.cbGraphEditStyle_SelectedIndexChanged);
+            // 
             // DocumentOptionsEditForm
             // 
             this.AcceptButton = this.btnOk;
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
+            this.Controls.Add(this.cbGraphEditStyle);
+            this.Controls.Add(this.label2);
             this.Controls.Add(this.ckDisplayTrainLabelsOnGraphs);
             this.Controls.Add(this.cbClockType);
             this.Controls.Add(this.label1);
@@ -94,5 +111,7 @@
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.ComboBox cbClockType;
         private System.Windows.Forms.CheckBox ckDisplayTrainLabelsOnGraphs;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.ComboBox cbGraphEditStyle;
     }
 }

--- a/Timetabler/DocumentOptionsEditForm.cs
+++ b/Timetabler/DocumentOptionsEditForm.cs
@@ -38,6 +38,7 @@ namespace Timetabler
         {
             InitializeComponent();
             cbClockType.Items.AddRange(HumanReadableEnum<ClockType>.GetClockTypes());
+            cbGraphEditStyle.Items.AddRange(HumanReadableEnum<GraphEditStyle>.GetGraphEditStyle());
         }
 
         private void UpdateViewFromModel()
@@ -54,6 +55,15 @@ namespace Timetabler
                 if (clockTypeItem != null && clockTypeItem.Value == _model.ClockType)
                 {
                     cbClockType.SelectedItem = clockTypeItem;
+                    break;
+                }
+            }
+            foreach (var item in cbGraphEditStyle.Items)
+            {
+                var gesItem = item as HumanReadableEnum<GraphEditStyle>;
+                if (gesItem != null && gesItem.Value == _model.GraphEditStyle)
+                {
+                    cbGraphEditStyle.SelectedItem = gesItem;
                     break;
                 }
             }
@@ -85,6 +95,22 @@ namespace Timetabler
             }
             Log.Trace("ckDisplayTrainLabelsOnGraphs is {0}", ckDisplayTrainLabelsOnGraphs.Checked);
             _model.DisplayTrainLabelsOnGraphs = ckDisplayTrainLabelsOnGraphs.Checked;
+        }
+
+        private void cbGraphEditStyle_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (_inViewUpdate || _model == null)
+            {
+                return;
+            }
+            var item = cbGraphEditStyle.SelectedItem as HumanReadableEnum<GraphEditStyle>;
+            if (item == null)
+            {
+                Log.Trace("cbGraphEditStyle: null item selected.");
+                return;
+            }
+            Log.Trace("cbGraphEditStyle: value is {0}", item.Name);
+            _model.GraphEditStyle = item.Value;
         }
     }
 }

--- a/Timetabler/DocumentOptionsEditForm.resx
+++ b/Timetabler/DocumentOptionsEditForm.resx
@@ -145,7 +145,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnOk.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="btnCancel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left, Right</value>
@@ -172,7 +172,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;btnCancel.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -199,13 +199,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="cbClockType.Location" type="System.Drawing.Point, System.Drawing">
-    <value>78, 16</value>
+    <value>141, 16</value>
   </data>
   <data name="cbClockType.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+    <value>199, 21</value>
   </data>
   <data name="cbClockType.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -220,7 +220,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cbClockType.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="ckDisplayTrainLabelsOnGraphs.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -229,7 +229,7 @@
     <value>MiddleRight</value>
   </data>
   <data name="ckDisplayTrainLabelsOnGraphs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 43</value>
+    <value>12, 70</value>
   </data>
   <data name="ckDisplayTrainLabelsOnGraphs.Size" type="System.Drawing.Size, System.Drawing">
     <value>166, 17</value>
@@ -250,6 +250,54 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;ckDisplayTrainLabelsOnGraphs.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 46</value>
+  </data>
+  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>123, 13</value>
+  </data>
+  <data name="label2.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="label2.Text" xml:space="preserve">
+    <value>Graph editing behaviour:</value>
+  </data>
+  <data name="&gt;&gt;label2.Name" xml:space="preserve">
+    <value>label2</value>
+  </data>
+  <data name="&gt;&gt;label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="cbGraphEditStyle.Location" type="System.Drawing.Point, System.Drawing">
+    <value>141, 43</value>
+  </data>
+  <data name="cbGraphEditStyle.Size" type="System.Drawing.Size, System.Drawing">
+    <value>199, 21</value>
+  </data>
+  <data name="cbGraphEditStyle.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;cbGraphEditStyle.Name" xml:space="preserve">
+    <value>cbGraphEditStyle</value>
+  </data>
+  <data name="&gt;&gt;cbGraphEditStyle.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbGraphEditStyle.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cbGraphEditStyle.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">

--- a/Timetabler/Helpers/HumanReadableEnum.cs
+++ b/Timetabler/Helpers/HumanReadableEnum.cs
@@ -112,5 +112,18 @@ namespace Timetabler.Helpers
                 new HumanReadableEnum<HalfOfDay> { Name = Resources.HumanReadableEnum_HalfOfDay_PM, Value = HalfOfDay.PM },
             };
         }
+
+        /// <summary>
+        /// Generate an array of <see cref="HumanReadableEnum{TEnum}" /> instances representing the values of the <see cref="GraphEditStyle" /> enumeration.
+        /// </summary>
+        /// <returns>An array of <see cref="HumanReadableEnum{TEnum}" /> instances.</returns>
+        public static HumanReadableEnum<GraphEditStyle>[] GetGraphEditStyle()
+        {
+            return new[]
+            {
+                new HumanReadableEnum<GraphEditStyle> { Name = Resources.HumanReadableEnum_GraphEditStyle_Free, Value = GraphEditStyle.Free },
+                new HumanReadableEnum<GraphEditStyle> { Name = Resources.HumanReadableEnum_GraphEditStyle_PreserveSectionTimes, Value = GraphEditStyle.PreserveSectionTimes }
+            };
+        }
     }
 }

--- a/Timetabler/MainForm.cs
+++ b/Timetabler/MainForm.cs
@@ -135,6 +135,7 @@ namespace Timetabler
             Model.DownTrainsDisplay.CheckCompulsaryLocationsAreVisible();
             Model.UpTrainsDisplay.CheckCompulsaryLocationsAreVisible();
             UpdateTrainGraphLocationModel();
+            trainGraph.Model.SetPropertiesFromDocumentOptions(Model.Options);
             _documentChanged = false;
         }
 

--- a/Timetabler/MainForm.cs
+++ b/Timetabler/MainForm.cs
@@ -631,8 +631,7 @@ namespace Timetabler
                 return;
             }
             doef.Model.CopyTo(Model.Options);
-            trainGraph.Model.DisplayTrainLabels = Model.Options.DisplayTrainLabelsOnGraphs;
-            trainGraph.Model.TooltipFormattingString = Model.Options.FormattingStrings.Tooltip;
+            trainGraph.Model.SetPropertiesFromDocumentOptions(Model.Options);
             trainGraph.Invalidate();
             Model.RefreshTrainDisplayFormatting();
             UpdateSignalboxHours();
@@ -689,7 +688,13 @@ namespace Timetabler
                 newDocument.Signalboxes = template.Signalboxes;
             }
             Model = newDocument;
-            trainGraph.Model = new TrainGraphModel { LocationList = Model.LocationList, TrainList = Model.TrainList, DisplayTrainLabels = template.DocumentOptions.DisplayTrainLabelsOnGraphs };            
+            trainGraph.Model = new TrainGraphModel
+            {
+                LocationList = Model.LocationList,
+                TrainList = Model.TrainList,
+                DisplayTrainLabels = template.DocumentOptions.DisplayTrainLabelsOnGraphs,
+                GraphEditStyle = Model.Options.GraphEditStyle,
+            };            
             UpdateFields();
             Model.UpdateTrainDisplays();
             _documentChanged = false;

--- a/Timetabler/Resources.Designer.cs
+++ b/Timetabler/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Timetabler {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -156,6 +156,24 @@ namespace Timetabler {
         internal static string HumanReadableEnum_DashStyle_Solid {
             get {
                 return ResourceManager.GetString("HumanReadableEnum_DashStyle_Solid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Free edit.
+        /// </summary>
+        internal static string HumanReadableEnum_GraphEditStyle_Free {
+            get {
+                return ResourceManager.GetString("HumanReadableEnum_GraphEditStyle_Free", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not alter section times when editing.
+        /// </summary>
+        internal static string HumanReadableEnum_GraphEditStyle_PreserveSectionTimes {
+            get {
+                return ResourceManager.GetString("HumanReadableEnum_GraphEditStyle_PreserveSectionTimes", resourceCulture);
             }
         }
         

--- a/Timetabler/Resources.resx
+++ b/Timetabler/Resources.resx
@@ -150,6 +150,12 @@
   <data name="HumanReadableEnum_DashStyle_Solid" xml:space="preserve">
     <value>Solid</value>
   </data>
+  <data name="HumanReadableEnum_GraphEditStyle_Free" xml:space="preserve">
+    <value>Free edit</value>
+  </data>
+  <data name="HumanReadableEnum_GraphEditStyle_PreserveSectionTimes" xml:space="preserve">
+    <value>Do not alter section times when editing</value>
+  </data>
   <data name="HumanReadableEnum_HalfOfDay_AM" xml:space="preserve">
     <value>a.m.</value>
   </data>


### PR DESCRIPTION
This is initial functionality, but covers some basic logic around preventing the graph editor from changing dwell times or section times, if that behavioural option is selected.